### PR TITLE
feat: Show processing and failed uploads

### DIFF
--- a/frontend/docs/docs/user-guide/archived-items.md
+++ b/frontend/docs/docs/user-guide/archived-items.md
@@ -14,7 +14,7 @@ The status of an archived item depends on its type. Uploads can have one of the 
 | ---- | ---- |
 | <span class="status-violet-600"><span class="animate-pulse">:btrix-status-dot:</span> Processing Upload</span> | The uploaded WACZ file is being processed and its pages indexed. |
 | <span class="status-green-600">:bootstrap-upload: Uploaded</span> | Processing has completed and the archived item is ready to replay. |
-| <span class="status-red-600">:bootstrap-x-octagon-fill: Failed</span> | Processing encountered an error and the upload could not be completed. |
+| <span class="status-red-600">:bootstrap-x-octagon-fill: Processing Failed</span> | Processing encountered an error and the upload could not be completed. |
 
 Crawls can have one of the following statuses:
 

--- a/frontend/src/components/ui/badge.ts
+++ b/frontend/src/components/ui/badge.ts
@@ -94,7 +94,7 @@ export class Badge extends TailwindElement {
                 neutral: tw`bg-neutral-100 text-neutral-600`,
                 "high-contrast": tw`bg-neutral-600 text-neutral-0`,
                 primary: tw`bg-primary text-neutral-0`,
-                notification: tw`bg-rose-600 text-neutral-0`,
+                notification: tw`bg-rose-500 text-neutral-0 ring-white/50`,
                 lime: tw`bg-lime-50 text-lime-600`,
                 cyan: tw`bg-cyan-50 text-cyan-600`,
                 sky: tw`bg-sky-50 text-sky-700`,

--- a/frontend/src/components/ui/badge.ts
+++ b/frontend/src/components/ui/badge.ts
@@ -11,6 +11,7 @@ export type BadgeVariant =
   | "danger"
   | "neutral"
   | "primary"
+  | "notification"
   | "lime"
   | "cyan"
   | "sky"
@@ -75,6 +76,7 @@ export class Badge extends TailwindElement {
                   neutral: tw`bg-neutral-100 text-neutral-600 ring-neutral-300`,
                   "high-contrast": tw`bg-neutral-0 text-neutral-700 ring-neutral-600`,
                   primary: tw`bg-white text-primary ring-primary`,
+                  notification: tw`bg-rose-50 text-rose-700 ring-rose-400`,
                   lime: tw`bg-lime-50 text-lime-600 ring-lime-600`,
                   cyan: tw`bg-cyan-50 text-cyan-600 ring-cyan-600`,
                   sky: tw`bg-sky-50 text-sky-700 ring-sky-700`,
@@ -92,6 +94,7 @@ export class Badge extends TailwindElement {
                 neutral: tw`bg-neutral-100 text-neutral-600`,
                 "high-contrast": tw`bg-neutral-600 text-neutral-0`,
                 primary: tw`bg-primary text-neutral-0`,
+                notification: tw`bg-rose-600 text-neutral-0`,
                 lime: tw`bg-lime-50 text-lime-600`,
                 cyan: tw`bg-cyan-50 text-cyan-600`,
                 sky: tw`bg-sky-50 text-sky-700`,

--- a/frontend/src/features/archived-items/archived-item-state-filter.ts
+++ b/frontend/src/features/archived-items/archived-item-state-filter.ts
@@ -15,20 +15,23 @@ import {
   state,
 } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import uniq from "lodash/fp/uniq";
 import { isFocusable } from "tabbable";
 
 import { CrawlStatus } from "./crawl-status";
+import { UploadStatus } from "./upload-status";
 
 import { BtrixElement } from "@/classes/BtrixElement";
 import type { BtrixChangeEvent } from "@/events/btrix-change";
-import { UPLOAD_STATES, type CrawlState } from "@/types/crawlState";
-import { finishedCrawlStates } from "@/utils/crawler";
+import { type ArchivedItem } from "@/types/crawler";
+import { type CrawlState } from "@/types/crawlState";
+import { finishedCrawlStates, uploadStates } from "@/utils/crawler";
 import { isNotEqual } from "@/utils/is-not-equal";
 import { tw } from "@/utils/tailwind";
 
 const MAX_STATES_IN_LABEL = 2;
 
-const filterStates = [...finishedCrawlStates, ...UPLOAD_STATES] as CrawlState[];
+const filterStates = uniq([...finishedCrawlStates, ...uploadStates]);
 
 type ChangeArchivedItemStateEventDetails = CrawlState[];
 
@@ -41,6 +44,9 @@ export type BtrixChangeArchivedItemStateFilterEvent =
 @customElement("btrix-archived-item-state-filter")
 @localized()
 export class ArchivedItemStateFilter extends BtrixElement {
+  @property({ type: String })
+  itemType?: ArchivedItem["type"];
+
   @property({ type: Array })
   states?: CrawlState[];
 
@@ -226,13 +232,22 @@ export class ArchivedItemStateFilter extends BtrixElement {
   }
 
   private renderList(opts: { item: CrawlState }[]) {
+    const uploads = this.itemType === "upload";
+    const validStates = uploads ? uploadStates : finishedCrawlStates;
+
     const state = (state: CrawlState) => {
       const checked = this.selected.get(state) === true;
 
-      const { icon, label } = CrawlStatus.getContent({
-        state,
-        originalState: state,
-      });
+      if (!checked && !validStates.includes(state)) {
+        return;
+      }
+
+      const { icon, label } = uploads
+        ? UploadStatus.getContentForState(state)
+        : CrawlStatus.getContent({
+            state,
+            originalState: state,
+          });
 
       return html`
         <li role="option" aria-checked=${checked}>

--- a/frontend/src/features/archived-items/delete-item-dialog.ts
+++ b/frontend/src/features/archived-items/delete-item-dialog.ts
@@ -10,7 +10,7 @@ import type { Dialog } from "@/components/ui/dialog";
 import type { ArchivedItemSectionName } from "@/pages/org/archived-item-detail/archived-item-detail";
 import { CommonTab, OrgTab, WorkflowTab } from "@/routes";
 import type { ArchivedItem } from "@/types/crawler";
-import { isCrawl, renderName } from "@/utils/crawler";
+import { isCrawl, isFailed, renderName } from "@/utils/crawler";
 import { pluralOf } from "@/utils/pluralize";
 
 /**
@@ -58,7 +58,9 @@ export class DeleteItemDialog extends BtrixElement {
       .label=${this.item
         ? isCrawl(this.item)
           ? msg("Delete Crawl?")
-          : msg("Delete Archived Item?")
+          : isFailed(this.item)
+            ? msg("Delete Failed Item?")
+            : msg("Delete Archived Item?")
         : msg("Delete")}
       .open=${this.open}
     >
@@ -104,7 +106,11 @@ export class DeleteItemDialog extends BtrixElement {
               this.dispatchEvent(new CustomEvent("btrix-confirm"));
             }}
           >
-            ${crawl ? msg("Delete Crawl") : msg("Delete Archived Item")}
+            ${crawl
+              ? msg("Delete Crawl")
+              : isFailed(item)
+                ? msg("Delete Failed Item")
+                : msg("Delete Archived Item")}
           </sl-button>
         </btrix-popover>
       </div>

--- a/frontend/src/features/archived-items/upload-status.ts
+++ b/frontend/src/features/archived-items/upload-status.ts
@@ -1,5 +1,5 @@
 import { localized, msg } from "@lit/localize";
-import { html } from "lit";
+import { html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { TailwindElement } from "@/classes/TailwindElement";
@@ -17,30 +17,39 @@ export class UploadStatus extends TailwindElement {
 
   static styles = [animatePulse];
 
-  render() {
+  static getContentForState(state?: UploadStatus["state"]): {
+    icon: TemplateResult;
+    label: string;
+  } {
     let icon = html`<sl-icon
       name="slash-circle"
       class="text-neutral-400"
     ></sl-icon>`;
-    let label: string | undefined = undefined;
+    let label = "";
 
-    if (this.state === "complete") {
+    if (state === "complete") {
       icon = html`<sl-icon name="upload" class="text-success"></sl-icon>`;
       label = msg("Uploaded");
-    } else if (this.state === "processing-upload") {
+    } else if (state === "processing-upload") {
       icon = html`<sl-icon
         name="dot"
         library="app"
         class="animatePulse text-violet-600"
       ></sl-icon>`;
       label = msg("Processing Upload");
-    } else if (this.state === "failed") {
+    } else if (state === "failed") {
       icon = html`<sl-icon
         name="x-octagon-fill"
         class="text-danger"
       ></sl-icon>`;
       label = msg("Processing Failed");
     }
+
+    return { icon, label };
+  }
+
+  render() {
+    const { icon, label } = UploadStatus.getContentForState(this.state);
 
     return labelWithIcon({
       icon,

--- a/frontend/src/features/archived-items/upload-status.ts
+++ b/frontend/src/features/archived-items/upload-status.ts
@@ -39,7 +39,7 @@ export class UploadStatus extends TailwindElement {
         name="x-octagon-fill"
         class="text-danger"
       ></sl-icon>`;
-      label = msg("Failed");
+      label = msg("Processing Failed");
     }
 
     return labelWithIcon({

--- a/frontend/src/pages/admin/crawls.ts
+++ b/frontend/src/pages/admin/crawls.ts
@@ -86,7 +86,7 @@ export class Crawls extends BtrixElement {
   private filterBy: Partial<Record<keyof Crawl, unknown>> & {
     state?: readonly CrawlState[];
   } = {
-    state: activeCrawlStates as readonly CrawlState[],
+    state: activeCrawlStates,
   };
 
   readonly #poll = new PollTask(this, {

--- a/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
+++ b/frontend/src/pages/org/archived-item-detail/archived-item-detail.ts
@@ -804,7 +804,7 @@ export class ArchivedItemDetail extends BtrixElement {
         >
         <sl-menu>
           ${when(
-            this.isCrawler,
+            this.isCrawler && isSuccessfullyFinished(this.item),
             () => html`
               <sl-menu-item @click=${this.openMetadataEditor}>
                 <sl-icon name="pencil" slot="prefix"></sl-icon>
@@ -899,7 +899,7 @@ export class ArchivedItemDetail extends BtrixElement {
                   ? msg("Delete Crawl")
                   : isSuccess
                     ? msg("Delete Archived Item")
-                    : msg("Delete Item")}
+                    : msg("Delete Failed Item")}
               </sl-menu-item>
             `,
           )}
@@ -1002,7 +1002,11 @@ export class ArchivedItemDetail extends BtrixElement {
           item.type === "upload"
             ? html`
                 <btrix-desc-list-item label=${msg("Uploaded")}>
-                  ${this.formattedFinishedDate}
+                  <btrix-format-date
+                    date=${item.started}
+                    dateStyle="long"
+                    timeStyle="long"
+                  ></btrix-format-date>
                 </btrix-desc-list-item>
               `
             : html`

--- a/frontend/src/pages/org/archived-item-detail/templates/badges.ts
+++ b/frontend/src/pages/org/archived-item-detail/templates/badges.ts
@@ -5,7 +5,7 @@ import { when } from "lit/directives/when.js";
 
 import { iconFor, labelFor, variantFor } from "@/features/qa/review-status";
 import { type ArchivedItem } from "@/types/crawler";
-import { isCrawl } from "@/utils/crawler";
+import { isCrawl, isSuccessfullyFinished } from "@/utils/crawler";
 import localize from "@/utils/localize";
 import { pluralOf } from "@/utils/pluralize";
 import appState from "@/utils/state";
@@ -59,9 +59,16 @@ const qaReviewBadge = (reviewStatus: ArchivedItem["reviewStatus"]) => html`
 `;
 
 export const badges = (item: ArchivedItem) => {
-  return html`<div class="flex flex-wrap gap-3 whitespace-nowrap">
-    ${itemTypeBadge(item.type)} ${collectionBadge(item.collectionIds.length)}
-    ${isCrawl(item) ? html`${qaReviewBadge(item.reviewStatus)} ` : nothing}
+  return html`<div
+    class="flex flex-wrap items-center gap-3 whitespace-nowrap py-px"
+  >
+    ${itemTypeBadge(item.type)}
+    ${when(
+      isSuccessfullyFinished(item),
+      () =>
+        html`${collectionBadge(item.collectionIds.length)}
+        ${isCrawl(item) ? html`${qaReviewBadge(item.reviewStatus)}` : nothing}`,
+    )}
     ${when(
       appState.featureFlags.has("dedupeEnabled"),
       () => html`

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -1,7 +1,7 @@
 import { localized, msg, str } from "@lit/localize";
 import { Task } from "@lit/task";
 import type { SlSelect } from "@shoelace-style/shoelace";
-import { html, nothing, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -440,6 +440,7 @@ export class CrawlsList extends BtrixElement {
       itemType: ArchivedItem["type"] | null;
       label: string;
       icon?: string;
+      badge?: () => TemplateResult | void;
     }[] = [
       {
         itemType: null,
@@ -455,6 +456,7 @@ export class CrawlsList extends BtrixElement {
         itemType: "upload",
         icon: "upload",
         label: msg("Uploads"),
+        badge: this.renderUploadBadge,
       },
     ];
 
@@ -484,7 +486,7 @@ export class CrawlsList extends BtrixElement {
             classNames: tw`mb-3`,
           })}
           <div class="mb-3 flex gap-2">
-            ${listTypes.map(({ label, itemType, icon }) => {
+            ${listTypes.map(({ label, itemType, icon, badge }) => {
               const isSelected = itemType === this.itemType;
               return html` <btrix-navigation-button
                 ?active=${isSelected}
@@ -496,6 +498,7 @@ export class CrawlsList extends BtrixElement {
               >
                 ${icon ? html`<sl-icon name=${icon}></sl-icon>` : ""}
                 <span>${label}</span>
+                ${badge ? badge() : nothing}
               </btrix-navigation-button>`;
             })}
           </div>
@@ -536,6 +539,10 @@ export class CrawlsList extends BtrixElement {
       )}
     `;
   }
+
+  private readonly renderUploadBadge = () => {
+    // return html`<btrix-badge variant="notification" pill></btrix-badge>`;
+  };
 
   private readonly renderArchivedItems = ({
     items,

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -831,7 +831,7 @@ export class CrawlsList extends BtrixElement {
 
     return html`
       ${when(
-        this.isCrawler,
+        this.isCrawler && isSuccessfullyFinished(item),
         () => html`
           <sl-menu-item
             @click=${async () => {
@@ -899,7 +899,7 @@ export class CrawlsList extends BtrixElement {
         ${msg("Copy Item ID")}
       </sl-menu-item>
       ${when(
-        this.isCrawler && (item.type !== "crawl" || !isActive(item)),
+        this.isCrawler && (item.type === "crawl" || !isActive(item)),
         () => html`
           <sl-divider></sl-divider>
           <sl-menu-item
@@ -907,7 +907,9 @@ export class CrawlsList extends BtrixElement {
             @click=${() => this.confirmDeleteItem(item)}
           >
             <sl-icon name="trash3" slot="prefix"></sl-icon>
-            ${msg("Delete Item")}
+            ${isSuccessfullyFinished(item)
+              ? msg("Delete Archived Item")
+              : msg("Delete Failed Item")}
           </sl-menu-item>
         `,
       )}

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -1,3 +1,4 @@
+import { ContextConsumer } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
 import type { SlSelect } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
@@ -22,6 +23,7 @@ import {
 import type { BtrixSearchComboboxSelectEvent } from "@/components/ui/search-combobox";
 import type { TagFilter } from "@/components/ui/tag-filter/tag-filter";
 import type { BtrixChangeTagFilterEvent } from "@/components/ui/tag-filter/types";
+import orgUploadsContext from "@/context/org-uploads";
 import { ClipboardController } from "@/controllers/clipboard";
 import PollTask from "@/controllers/poll";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
@@ -120,6 +122,21 @@ export class CrawlsList extends BtrixElement {
     name: msg("Name"),
     firstSeed: msg("Crawl Start URL"),
   };
+
+  readonly #orgUploads = new ContextConsumer(this, {
+    context: orgUploadsContext,
+    subscribe: true,
+    callback: (value) => {
+      console.log("upload changed", Object.values(value)[0]);
+      if (Object.values(value).some(({ loaded, total }) => loaded === total)) {
+        void this.incompleteUploadsTask.run();
+
+        if (this.itemType === "upload") {
+          void this.archivedItemsTask.run();
+        }
+      }
+    },
+  });
 
   @property({ type: Boolean })
   isCrawler!: boolean;
@@ -374,7 +391,7 @@ export class CrawlsList extends BtrixElement {
     timeoutSeconds: POLL_INTERVAL_SECONDS,
   });
 
-  private readonly activeUploadsTask = new PollTask(this, {
+  private readonly incompleteUploadsTask = new PollTask(this, {
     task: async (_args, { signal }) => {
       const data = await this.getArchivedItems(
         {
@@ -554,7 +571,7 @@ export class CrawlsList extends BtrixElement {
   }
 
   private readonly renderUploadsBadge = () => {
-    const total = this.activeUploadsTask.value?.total;
+    const total = this.incompleteUploadsTask.value?.total;
 
     if (!total) return;
 

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -462,6 +462,13 @@ export class CrawlsList extends BtrixElement {
     }
 
     if (changedProperties.has("itemType")) {
+      if (
+        this.itemType === "upload" &&
+        this.activeUploadsTotalTask.previousValue !== undefined
+      ) {
+        void this.activeUploadsTotalTask.run();
+      }
+
       if (changedProperties.get("itemType") !== undefined) {
         this.filterBy.setValue({});
       }

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -36,11 +36,11 @@ import { UPLOAD_STATES, type CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import {
   finishedCrawlStates,
-  inactiveCrawlStates,
   isActive,
   isCrawl,
   isSuccessfullyFinished,
   renderName,
+  uploadStates,
 } from "@/utils/crawler";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { tw } from "@/utils/tailwind";
@@ -354,7 +354,7 @@ export class CrawlsList extends BtrixElement {
             state: filterBy.state?.length
               ? filterBy.state
               : itemType === "upload"
-                ? [...inactiveCrawlStates, ...UPLOAD_STATES]
+                ? uploadStates
                 : finishedCrawlStates,
           },
           signal,
@@ -675,6 +675,7 @@ export class CrawlsList extends BtrixElement {
             ${msg("Filter by:")}
           </span>
           <btrix-archived-item-state-filter
+            itemType=${ifDefined(this.itemType ?? undefined)}
             .states=${this.filterBy.value.state}
             @btrix-change=${(e: BtrixChangeArchivedItemStateFilterEvent) => {
               this.filterBy.setValue({

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -1,5 +1,4 @@
 import { localized, msg, str } from "@lit/localize";
-import { Task } from "@lit/task";
 import type { SlSelect } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -24,6 +23,7 @@ import type { BtrixSearchComboboxSelectEvent } from "@/components/ui/search-comb
 import type { TagFilter } from "@/components/ui/tag-filter/tag-filter";
 import type { BtrixChangeTagFilterEvent } from "@/components/ui/tag-filter/types";
 import { ClipboardController } from "@/controllers/clipboard";
+import PollTask from "@/controllers/poll";
 import { SearchParamsValue } from "@/controllers/searchParamsValue";
 import { type BtrixChangeArchivedItemStateFilterEvent } from "@/features/archived-items/archived-item-state-filter";
 import { CrawlStatus } from "@/features/archived-items/crawl-status";
@@ -310,7 +310,7 @@ export class CrawlsList extends BtrixElement {
     this.filterByTagsType.setValue("or");
   }
 
-  private readonly archivedItemsTask = new Task(this, {
+  private readonly archivedItemsTask = new PollTask(this, {
     task: async (
       [
         itemType,
@@ -323,10 +323,6 @@ export class CrawlsList extends BtrixElement {
       ],
       { signal },
     ) => {
-      if (this.getArchivedItemsTimeout) {
-        window.clearTimeout(this.getArchivedItemsTimeout);
-      }
-
       try {
         const data = await this.getArchivedItems(
           {
@@ -340,10 +336,6 @@ export class CrawlsList extends BtrixElement {
           },
           signal,
         );
-
-        this.getArchivedItemsTimeout = window.setTimeout(() => {
-          void this.archivedItemsTask.run();
-        }, POLL_INTERVAL_SECONDS * 1000);
 
         return data;
       } catch (e) {
@@ -373,9 +365,8 @@ export class CrawlsList extends BtrixElement {
         this.filterByTags.value,
         this.filterByTagsType.value,
       ] as const,
+    timeoutSeconds: POLL_INTERVAL_SECONDS,
   });
-
-  private getArchivedItemsTimeout?: number;
 
   // For fuzzy search:
   private readonly searchKeys = ["id", "name", "firstSeed"];
@@ -428,11 +419,6 @@ export class CrawlsList extends BtrixElement {
       this.filterBy.setValue({});
       void this.fetchConfigSearchValues();
     }
-  }
-
-  disconnectedCallback(): void {
-    window.clearTimeout(this.getArchivedItemsTimeout);
-    super.disconnectedCallback();
   }
 
   render() {

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -123,13 +123,13 @@ export class CrawlsList extends BtrixElement {
     firstSeed: msg("Crawl Start URL"),
   };
 
+  // Update uploads list when user upload completes
   readonly #orgUploads = new ContextConsumer(this, {
     context: orgUploadsContext,
     subscribe: true,
     callback: (value) => {
-      console.log("upload changed", Object.values(value)[0]);
       if (Object.values(value).some(({ loaded, total }) => loaded === total)) {
-        void this.incompleteUploadsTask.run();
+        void this.activeUploadsTotalTask.run();
 
         if (this.itemType === "upload") {
           void this.archivedItemsTask.run();
@@ -391,22 +391,21 @@ export class CrawlsList extends BtrixElement {
     timeoutSeconds: POLL_INTERVAL_SECONDS,
   });
 
-  private readonly incompleteUploadsTask = new PollTask(this, {
+  private readonly activeUploadsTotalTask = new PollTask(this, {
     task: async (_args, { signal }) => {
       const data = await this.getArchivedItems(
         {
           itemType: "upload",
-          state: ["failed", ...UPLOAD_STATES],
+          state: UPLOAD_STATES,
           pagination: {
             page: 1,
-            // TODO Handle more than max page size
-            pageSize: 1000,
+            pageSize: 1,
           },
         },
         signal,
       );
 
-      return data;
+      return data.total;
     },
     args: () => [] as const,
     timeoutSeconds: POLL_INTERVAL_SECONDS,
@@ -571,7 +570,7 @@ export class CrawlsList extends BtrixElement {
   }
 
   private readonly renderUploadsBadge = () => {
-    const total = this.incompleteUploadsTask.value?.total;
+    const total = this.activeUploadsTotalTask.value;
 
     if (!total) return;
 

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -34,6 +34,7 @@ import { UPLOAD_STATES, type CrawlState } from "@/types/crawlState";
 import { isApiError } from "@/utils/api";
 import {
   finishedCrawlStates,
+  inactiveCrawlStates,
   isActive,
   isCrawl,
   isSuccessfullyFinished,
@@ -56,7 +57,7 @@ type SortDirection = (typeof SORT_DIRECTIONS)[number];
 
 type Keys<T> = (keyof T)[];
 
-const POLL_INTERVAL_SECONDS = 5;
+const POLL_INTERVAL_SECONDS = 30;
 const INITIAL_PAGE_SIZE = 20;
 const FILTER_BY_CURRENT_USER_STORAGE_KEY = "btrix.filterByCurrentUser.crawls";
 const sortableFields: Record<
@@ -324,7 +325,7 @@ export class CrawlsList extends BtrixElement {
       { signal },
     ) => {
       try {
-        const data = await this.getArchivedItems(
+        const data = this.getArchivedItems(
           {
             itemType,
             pagination,
@@ -333,6 +334,11 @@ export class CrawlsList extends BtrixElement {
             filterByCurrentUser,
             filterByTags,
             filterByTagsType,
+            state: filterBy.state?.length
+              ? filterBy.state
+              : itemType === "upload"
+                ? [...inactiveCrawlStates, ...UPLOAD_STATES]
+                : finishedCrawlStates,
           },
           signal,
         );
@@ -365,6 +371,27 @@ export class CrawlsList extends BtrixElement {
         this.filterByTags.value,
         this.filterByTagsType.value,
       ] as const,
+    timeoutSeconds: POLL_INTERVAL_SECONDS,
+  });
+
+  private readonly activeUploadsTask = new PollTask(this, {
+    task: async (_args, { signal }) => {
+      const data = await this.getArchivedItems(
+        {
+          itemType: "upload",
+          state: ["failed", ...UPLOAD_STATES],
+          pagination: {
+            page: 1,
+            // TODO Handle more than max page size
+            pageSize: 1000,
+          },
+        },
+        signal,
+      );
+
+      return data;
+    },
+    args: () => [] as const,
     timeoutSeconds: POLL_INTERVAL_SECONDS,
   });
 
@@ -442,7 +469,7 @@ export class CrawlsList extends BtrixElement {
         itemType: "upload",
         icon: "upload",
         label: msg("Uploads"),
-        badge: this.renderUploadBadge,
+        badge: this.renderUploadsBadge,
       },
     ];
 
@@ -526,8 +553,14 @@ export class CrawlsList extends BtrixElement {
     `;
   }
 
-  private readonly renderUploadBadge = () => {
-    // return html`<btrix-badge variant="notification" pill></btrix-badge>`;
+  private readonly renderUploadsBadge = () => {
+    const total = this.activeUploadsTask.value?.total;
+
+    if (!total) return;
+
+    return html`<btrix-badge variant="notification" pill>
+      ${this.localize.number(total, { notation: "compact" })}
+    </btrix-badge>`;
   };
 
   private readonly renderArchivedItems = ({
@@ -944,33 +977,30 @@ export class CrawlsList extends BtrixElement {
   private async getArchivedItems(
     params: {
       itemType: CrawlsList["itemType"];
+      state: readonly CrawlState[];
       pagination: CrawlsList["pagination"];
-      orderBy: CrawlsList["orderBy"]["value"];
-      filterBy: CrawlsList["filterBy"]["value"];
-      filterByCurrentUser: CrawlsList["filterByCurrentUser"]["value"];
-      filterByTags: CrawlsList["filterByTags"]["value"];
-      filterByTagsType: CrawlsList["filterByTagsType"]["value"];
+      orderBy?: CrawlsList["orderBy"]["value"];
+      filterBy?: CrawlsList["filterBy"]["value"];
+      filterByCurrentUser?: CrawlsList["filterByCurrentUser"]["value"];
+      filterByTags?: CrawlsList["filterByTags"]["value"];
+      filterByTagsType?: CrawlsList["filterByTagsType"]["value"];
     },
     signal: AbortSignal,
   ) {
-    const { id, ...filterBy } = params.filterBy;
+    const { id, ...filterBy } = params.filterBy || {};
     const query = queryString.stringify(
       {
         ...filterBy,
         ids: id ? [id] : undefined,
-        state: filterBy.state?.length
-          ? filterBy.state
-          : params.itemType === "upload"
-            ? [...finishedCrawlStates, ...UPLOAD_STATES]
-            : finishedCrawlStates,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
         tags: params.filterByTags,
         tagMatch: params.filterByTagsType,
         userid: params.filterByCurrentUser ? this.userInfo!.id : undefined,
-        sortBy: params.orderBy.field,
-        sortDirection: params.orderBy.direction === "desc" ? -1 : 1,
+        sortBy: params.orderBy?.field,
+        sortDirection: params.orderBy?.direction === "desc" ? -1 : 1,
         crawlType: params.itemType ?? undefined,
+        state: params.state,
       },
       {
         arrayFormat: "none",

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -1,5 +1,6 @@
 import { ContextConsumer } from "@lit/context";
 import { localized, msg, str } from "@lit/localize";
+import { deepArrayEquals } from "@lit/task/deep-equals.js";
 import type { SlSelect } from "@shoelace-style/shoelace";
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -42,6 +43,7 @@ import {
   renderName,
   uploadStates,
 } from "@/utils/crawler";
+import { isNotEqual } from "@/utils/is-not-equal";
 import { isArchivingDisabled } from "@/utils/orgs";
 import { tw } from "@/utils/tailwind";
 
@@ -342,7 +344,7 @@ export class CrawlsList extends BtrixElement {
       { signal },
     ) => {
       try {
-        const data = this.getArchivedItems(
+        const data = await this.getArchivedItems(
           {
             itemType,
             pagination,
@@ -388,6 +390,7 @@ export class CrawlsList extends BtrixElement {
         this.filterByTags.value,
         this.filterByTagsType.value,
       ] as const,
+    argsEqual: deepArrayEquals,
     timeoutSeconds: POLL_INTERVAL_SECONDS,
   });
 
@@ -459,7 +462,10 @@ export class CrawlsList extends BtrixElement {
     }
 
     if (changedProperties.has("itemType")) {
-      this.filterBy.setValue({});
+      if (changedProperties.get("itemType") !== undefined) {
+        this.filterBy.setValue({});
+      }
+
       void this.fetchConfigSearchValues();
     }
   }
@@ -677,10 +683,14 @@ export class CrawlsList extends BtrixElement {
             itemType=${ifDefined(this.itemType ?? undefined)}
             .states=${this.filterBy.value.state}
             @btrix-change=${(e: BtrixChangeArchivedItemStateFilterEvent) => {
-              this.filterBy.setValue({
-                ...this.filterBy.value,
-                state: e.detail.value,
-              });
+              const value = e.detail.value.length ? e.detail.value : undefined;
+
+              if (isNotEqual(value, this.filterBy.value.state)) {
+                this.filterBy.setValue({
+                  ...this.filterBy.value,
+                  state: value,
+                });
+              }
             }}
           ></btrix-archived-item-state-filter>
 
@@ -700,10 +710,14 @@ export class CrawlsList extends BtrixElement {
           <btrix-qa-review-filter
             .qaRatingRange=${this.filterBy.value.reviewStatus ?? null}
             @btrix-change=${(e: BtrixChangeQARatingFilterEvent) => {
-              this.filterBy.setValue({
-                ...this.filterBy.value,
-                reviewStatus: e.detail.value ?? undefined,
-              });
+              const value = e.detail.value ?? undefined;
+
+              if (this.filterBy.value.reviewStatus !== value) {
+                this.filterBy.setValue({
+                  ...this.filterBy.value,
+                  reviewStatus: value,
+                });
+              }
             }}
           ></btrix-qa-review-filter>
 

--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -454,7 +454,7 @@ export class CrawlsList extends BtrixElement {
       {
         itemType: "upload",
         icon: "upload",
-        label: msg("Uploaded Items"),
+        label: msg("Uploads"),
       },
     ];
 
@@ -967,9 +967,9 @@ export class CrawlsList extends BtrixElement {
         ids: id ? [id] : undefined,
         state: filterBy.state?.length
           ? filterBy.state
-          : params.itemType === "crawl"
-            ? finishedCrawlStates
-            : [...finishedCrawlStates, ...UPLOAD_STATES],
+          : params.itemType === "upload"
+            ? [...finishedCrawlStates, ...UPLOAD_STATES]
+            : finishedCrawlStates,
         page: params.pagination.page,
         pageSize: params.pagination.pageSize,
         tags: params.filterByTags,

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -18,6 +18,7 @@ import {
   RUNNING_STATES,
   SUCCESSFUL_AND_FAILED_STATES,
   SUCCESSFUL_STATES,
+  UPLOAD_STATES,
 } from "@/types/crawlState";
 import type { OrgData } from "@/types/org";
 import type { QARun } from "@/types/qa";
@@ -60,8 +61,10 @@ export function isRateLimited(
   return crawl.state === "rate-limited";
 }
 
-export function isActive({ state }: Partial<Crawl | QARun>) {
-  return (activeCrawlStates as readonly (typeof state)[]).includes(state);
+export function isActive({ state }: Partial<Crawl | Upload | QARun>) {
+  return (
+    [...activeCrawlStates, ...UPLOAD_STATES] as readonly (typeof state)[]
+  ).includes(state);
 }
 
 export function isSuccessfullyFinished({ state }: { state: string | null }) {
@@ -70,6 +73,12 @@ export function isSuccessfullyFinished({ state }: { state: string | null }) {
 
 export function isSkipped({ state }: { state: string | null }) {
   return state?.startsWith("skipped");
+}
+
+export function isFailed({ state }: { state: string | null }) {
+  return (
+    state && (FAILED_STATES as readonly string[]).some((str) => str === state)
+  );
 }
 
 export function isNotFailed({ state }: { state: string | null }) {

--- a/frontend/src/utils/crawler.ts
+++ b/frontend/src/utils/crawler.ts
@@ -19,6 +19,7 @@ import {
   SUCCESSFUL_AND_FAILED_STATES,
   SUCCESSFUL_STATES,
   UPLOAD_STATES,
+  type CrawlState,
 } from "@/types/crawlState";
 import type { OrgData } from "@/types/org";
 import type { QARun } from "@/types/qa";
@@ -27,9 +28,15 @@ import localize from "@/utils/localize";
 import { pluralOf } from "@/utils/pluralize";
 
 // Match backend TYPE_RUNNING_AND_WAITING_STATES in models.py
-export const activeCrawlStates = RUNNING_AND_WAITING_STATES;
-export const finishedCrawlStates = SUCCESSFUL_STATES;
+export const activeCrawlStates =
+  RUNNING_AND_WAITING_STATES as readonly CrawlState[];
+export const finishedCrawlStates = SUCCESSFUL_STATES as readonly CrawlState[];
 export const inactiveCrawlStates = SUCCESSFUL_AND_FAILED_STATES;
+export const uploadStates = [
+  "complete",
+  "failed",
+  ...UPLOAD_STATES,
+] as readonly CrawlState[];
 
 export const DEFAULT_MAX_SCALE = 8;
 


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3586

## Changes

- Rename “Uploaded Items” tab -> “Uploads” and show all upload states, with indicator of number of processing uploads
- Update upload status filters
- Prevent editing failed item
- Update failed item labels from "archived" -> "failed"
- Refactor archived items list to use `PollController` and fix change detection being triggered too much by filters


## Manual testing

1. Log in as crawler
2. Go to "Archived Items"
3. Upload a malformed WACZ file
4. Wait for upload to finish. Verify `1` is displayed in "Uploads" button
5. Wait for upload to finish processing. Verify failed upload is shown

## Screenshots

| Page | Image/video |
| ---- | ----------- |
| Archived Items / Uploads | <img width="1259" height="395" alt="Screenshot 2026-08-18 at 7 21 36 PM" src="https://github.com/user-attachments/assets/52be0a63-959e-49ce-852f-cc52c39dcd08" /> |
| Archived Items / Uploads | <img width="303" height="245" alt="Screenshot 2026-08-18 at 7 22 07 PM" src="https://github.com/user-attachments/assets/175b9f24-4152-4653-a543-cb5577880ee5" /> |
| Archived Items / Upload | <img width="511" height="174" alt="Screenshot 2026-08-18 at 8 04 57 PM" src="https://github.com/user-attachments/assets/5d85cba2-c3ab-4ea7-9eaf-51dbda677a8d" /> |
| Failed Upload | <img width="209" height="182" alt="Screenshot 2026-08-18 at 8 05 10 PM" src="https://github.com/user-attachments/assets/609bc372-5ff2-4677-9248-33aa6e1181eb" /> |
| Failed Upload | <img width="497" height="455" alt="Screenshot 2026-08-18 at 7 22 15 PM" src="https://github.com/user-attachments/assets/74fa18d6-f5c9-48f0-b39b-c822a7ca1a53" /> |


<!-- ## Follow-ups -->
