### PR TITLE
Improve background job retries

### DIFF
--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import structlog
 
 from .logger import init_logging, set_log_context
+from .models import BgJobExitCode as ExitCode
 from .models import BgJobType
 from .ops import init_ops
 from .utils import btrix_env
@@ -47,7 +48,7 @@ async def main():
                 "Kubernetes not detected (KUBERNETES_SERVICE_HOST is not set), Exiting"
             ),
         )
-        return 1
+        return ExitCode.FATAL_DONT_RETRY
 
     (
         org_ops,
@@ -74,37 +75,37 @@ async def main():
     if job_type == BgJobType.OPTIMIZE_PAGES:
         try:
             await page_ops.optimize_crawl_pages(version=2)
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="optimize_pages failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.CLEANUP_SEED_FILES:
         try:
             await file_ops.cleanup_unused_seed_files()
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="cleanup_seed_files failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.RETRY_STUCK_UPLOADS:
         try:
             await upload_ops.retry_stuck_uploads()
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     # Run job (org-specific)
     if not oid:
@@ -112,7 +113,7 @@ async def main():
             "org_id_missing",
             unstructured_message="Org id missing, quitting",
         )
-        return 1
+        return ExitCode.FATAL_DONT_RETRY
 
     org = await org_ops.get_org_by_id(UUID(oid))
     if not org:
@@ -120,31 +121,31 @@ async def main():
             "org_id_invalid",
             unstructured_message="Org id invalid, quitting",
         )
-        return 1
+        return ExitCode.FATAL_DONT_RETRY
 
     if job_type == BgJobType.DELETE_ORG:
         try:
             await org_ops.delete_org_and_data(org, user_manager)
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="delete_org_and_data failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.RECALCULATE_ORG_STATS:
         try:
             await org_ops.recalculate_storage(org)
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="recalculate_storage failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.READD_ORG_PAGES:
         try:
@@ -154,14 +155,14 @@ async def main():
                 await page_ops.re_add_crawl_pages(crawl_id=crawl_id, oid=org.id)
 
             await coll_ops.recalculate_org_collection_stats(org)
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="readd_org_pages failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.UPDATE_COLL_STATS:
         crawl_logger.info(
@@ -191,36 +192,36 @@ async def main():
                     "No changes to collection since start of last update, job complete"
                 ),
             )
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
                 unstructured_message="update_collection_stats failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     if job_type == BgJobType.POSTPROCESS_UPLOAD:
         if not crawl_id:
             crawl_logger.critical(
                 "missing_crawl_id",
             )
-            return 1
+            return ExitCode.ERROR
         try:
             await upload_ops.post_process_upload(crawl_id, org)
-            return 0
+            return ExitCode.SUCCESS
         # pylint: disable=broad-exception-caught
         except Exception:
             crawl_logger.exception(
                 "bg_job_failed",
             )
-            return 1
+            return ExitCode.ERROR
 
     crawl_logger.critical(
         "unsupported_job_type",
         unstructured_message=f"Provided job type {job_type} not currently supported",
     )
-    return 1
+    return ExitCode.ERROR
 
 
 # # ============================================================================

--- a/backend/btrixcloud/main_bg.py
+++ b/backend/btrixcloud/main_bg.py
@@ -206,7 +206,7 @@ async def main():
             crawl_logger.critical(
                 "missing_crawl_id",
             )
-            return ExitCode.ERROR
+            return ExitCode.FATAL_DONT_RETRY
         try:
             await upload_ops.post_process_upload(crawl_id, org)
             return ExitCode.SUCCESS

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -3252,6 +3252,15 @@ class BgJobType(StrEnum):
 
 
 # ============================================================================
+class BgJobExitCode(IntEnum):
+    """Background job exit codes"""
+
+    SUCCESS = 0
+    ERROR = 1
+    FATAL_DONT_RETRY = 2
+
+
+# ============================================================================
 class BackgroundJob(BaseMongoModel):
     """Model for tracking background jobs"""
 

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1647,15 +1647,16 @@ class OrgOps(BaseOrgs):
         # Delete invites
         await self.invites_db.delete_many({"oid": org.id})
 
-        # Delete org
-        await self.orgs.delete_one({"_id": org.id})
-
         # Delete all background jobs except this one from database,
         # so that we are left with some record of the org having
         # existed and successfully deleted
         await self.jobs_db.delete_one(
             {"oid": org.id, "type": {"$ne": BgJobType.DELETE_ORG}}
         )
+
+        # Delete org last so that if the job fails at any point before
+        # this and need to be retried, the org still exists
+        await self.orgs.delete_one({"_id": org.id})
 
     async def recalculate_storage(self, org: Organization) -> dict[str, bool]:
         """Recalculate org storage use"""

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1653,8 +1653,8 @@ class OrgOps(BaseOrgs):
         # Delete all background jobs except this one from database,
         # so that we are left with some record of the org having
         # existed and successfully deleted
-        await self.orgs.delete_one(
-            {"_id": org.id, "type": {"$ne": BgJobType.DELETE_ORG}}
+        await self.jobs_db.delete_one(
+            {"oid": org.id, "type": {"$ne": BgJobType.DELETE_ORG}}
         )
 
     async def recalculate_storage(self, org: Organization) -> dict[str, bool]:

--- a/backend/btrixcloud/orgs.py
+++ b/backend/btrixcloud/orgs.py
@@ -1650,7 +1650,7 @@ class OrgOps(BaseOrgs):
         # Delete all background jobs except this one from database,
         # so that we are left with some record of the org having
         # existed and successfully deleted
-        await self.jobs_db.delete_one(
+        await self.jobs_db.delete_many(
             {"oid": org.id, "type": {"$ne": BgJobType.DELETE_ORG}}
         )
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -1169,7 +1169,6 @@ class PageOps:
                     break
 
                 crawl_id = next_crawl.get("_id")
-                prev_crawl_version = next_crawl.get("version")
 
                 migrate_logger.info(
                     "crawl_migration_processing",
@@ -1216,10 +1215,10 @@ class PageOps:
                     )
                 # pylint: disable=broad-exception-caught
                 except Exception:
-                    # Update crawl version and unset isMigrating
+                    # Unset isMigrating so we can re-process this crawl on retry
                     await self.crawls.find_one_and_update(
                         {"_id": crawl_id},
-                        {"$set": {"version": prev_crawl_version, "isMigrating": False}},
+                        {"$set": {"isMigrating": False}},
                     )
 
         await process_finished_crawls()

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -867,18 +867,18 @@ class PageOps:
     async def re_add_crawl_pages(self, crawl_id: str, oid: UUID | None = None):
         """Delete existing pages for crawl and re-add from WACZs."""
 
+        is_upload = await self.crawl_ops.is_upload(crawl_id)
+        crawl_type = "upload" if is_upload else "crawl"
+        readd_logger = logger.bind(crawl_id=crawl_id, crawl_type=crawl_type, oid=oid)
+
+        readd_logger.info(
+            "crawl_processing",
+            unstructured_message=f"Processing {crawl_type} {crawl_id}",
+        )
+
+        qa_temp_db_name = ""
+
         try:
-            is_upload = await self.crawl_ops.is_upload(crawl_id)
-            crawl_type = "upload" if is_upload else "crawl"
-
-            readd_logger = logger.bind(
-                crawl_id=crawl_id, crawl_type=crawl_type, oid=oid
-            )
-
-            readd_logger.info(
-                "crawl_processing",
-                unstructured_message=f"Processing {crawl_type} {crawl_id}",
-            )
             if not is_upload:
                 ts_now = dt_now().strftime("%Y%m%d%H%M%S")
                 qa_temp_db_name = f"pages-qa-temp-{crawl_id}-{ts_now}"
@@ -943,15 +943,19 @@ class PageOps:
                 )
 
                 assert await cursor.to_list() == []
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            readd_logger.exception("re_add_crawl_pages_failed")
+            raise
+        finally:
+            if qa_temp_db_name:
+                qa_temp_db = self.mdb[qa_temp_db_name]
                 await qa_temp_db.drop()
                 readd_logger.info(
                     "temp_db_dropped",
                     qa_temp_db_name=qa_temp_db_name,
                     unstructured_message=f"Dropped temp db {qa_temp_db_name}",
                 )
-        # pylint: disable=broad-exception-caught
-        except Exception:
-            readd_logger.exception("page_re_add_error")
 
     async def re_add_all_crawl_pages(
         self, org: Organization, crawl_type: str | None = None
@@ -966,6 +970,8 @@ class PageOps:
 
         count = 1
         total = await self.crawls.count_documents(match_query)
+        failures: list[str] = []
+
         async for crawl in self.crawls.find(match_query, projection={"_id": 1}):
             logger.info(
                 "crawl_batch_progress",
@@ -975,8 +981,22 @@ class PageOps:
                 oid=org.id,
                 unstructured_message=f"Processing crawl {count} of {total}",
             )
-            await self.re_add_crawl_pages(crawl.get("_id"), org.id)
+            crawl_id = crawl.get("_id")
+            try:
+                await self.re_add_crawl_pages(crawl_id, org.id)
+            except:
+                failures.append(crawl_id)
             count += 1
+
+        if failures:
+            logger.error(
+                "re_add_pages_errors",
+                failed_crawls=failures,
+                failed_count=len(failures),
+                total=total,
+                oid=org.id,
+            )
+            raise HTTPException(status_code=400, detail="re_add_pages_error")
 
     async def get_qa_run_aggregate_counts(
         self,
@@ -1132,7 +1152,13 @@ class PageOps:
                     match_query,
                     {"$set": {"isMigrating": True}},
                     sort=[("finished", -1)],
-                    projection={"_id": 1, "pageCount": 1, "stats": 1, "state": 1},
+                    projection={
+                        "_id": 1,
+                        "pageCount": 1,
+                        "stats": 1,
+                        "state": 1,
+                        "version": 1,
+                    },
                 )
                 if next_crawl is None:
                     migrate_logger.info(
@@ -1142,48 +1168,58 @@ class PageOps:
                     break
 
                 crawl_id = next_crawl.get("_id")
+                prev_crawl_version = next_crawl.get("version")
+
                 migrate_logger.info(
                     "crawl_migration_processing",
                     crawl_id=crawl_id,
                     unstructured_message=f"Processing crawl: {crawl_id}",
                 )
 
-                # Re-add crawl pages if at least one page doesn't have filename set
-                has_page_no_filename = await self.pages.find_one(
-                    {"crawl_id": crawl_id, "filename": None}
-                )
-                if has_page_no_filename:
-                    migrate_logger.info(
-                        "pages_reimporting_migrate_v2",
-                        crawl_id=crawl_id,
-                        unstructured_message="Re-importing pages to migrate to v2",
+                try:
+                    # Re-add crawl pages if at least one page doesn't have filename set
+                    has_page_no_filename = await self.pages.find_one(
+                        {"crawl_id": crawl_id, "filename": None}
                     )
-                    await self.re_add_crawl_pages(crawl_id)
-                elif (
-                    next_crawl.get("pageCount") == 0
-                    and next_crawl.get("stats", {}).get("done", 0) > 0
-                    and next_crawl.get("state") not in ["canceled", "failed"]
-                ):
-                    migrate_logger.info(
-                        "pages_missing_import_migrate_v2",
-                        crawl_id=crawl_id,
-                        unstructured_message=(
-                            "Pages likely missing, importing pages to migrate to v2"
-                        ),
-                    )
-                    await self.re_add_crawl_pages(crawl_id)
-                else:
-                    migrate_logger.info(
-                        "pages_filename_exists_set_v2",
-                        crawl_id=crawl_id,
-                        unstructured_message="Pages already have filename, set to v2",
-                    )
+                    if has_page_no_filename:
+                        migrate_logger.info(
+                            "pages_reimporting_migrate_v2",
+                            crawl_id=crawl_id,
+                            unstructured_message="Re-importing pages to migrate to v2",
+                        )
+                        await self.re_add_crawl_pages(crawl_id)
+                    elif (
+                        next_crawl.get("pageCount") == 0
+                        and next_crawl.get("stats", {}).get("done", 0) > 0
+                        and next_crawl.get("state") not in ["canceled", "failed"]
+                    ):
+                        migrate_logger.info(
+                            "pages_missing_import_migrate_v2",
+                            crawl_id=crawl_id,
+                            unstructured_message=(
+                                "Pages likely missing, importing pages to migrate to v2"
+                            ),
+                        )
+                        await self.re_add_crawl_pages(crawl_id)
+                    else:
+                        migrate_logger.info(
+                            "pages_filename_exists_set_v2",
+                            crawl_id=crawl_id,
+                            unstructured_message="Pages already have filename, set to v2",
+                        )
 
-                # Update crawl version and unset isMigrating
-                await self.crawls.find_one_and_update(
-                    {"_id": crawl_id},
-                    {"$set": {"version": version, "isMigrating": False}},
-                )
+                    # Update crawl version and unset isMigrating
+                    await self.crawls.find_one_and_update(
+                        {"_id": crawl_id},
+                        {"$set": {"version": version, "isMigrating": False}},
+                    )
+                # pylint: disable=broad-exception-caught
+                except Exception:
+                    # Update crawl version and unset isMigrating
+                    await self.crawls.find_one_and_update(
+                        {"_id": crawl_id},
+                        {"$set": {"version": prev_crawl_version, "isMigrating": False}},
+                    )
 
         await process_finished_crawls()
 

--- a/backend/btrixcloud/pages.py
+++ b/backend/btrixcloud/pages.py
@@ -984,7 +984,8 @@ class PageOps:
             crawl_id = crawl.get("_id")
             try:
                 await self.re_add_crawl_pages(crawl_id, org.id)
-            except:
+            # pylint: disable=broad-exception-caught
+            except Exception:
                 failures.append(crawl_id)
             count += 1
 

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -4,16 +4,16 @@ metadata:
   name: "{{ id }}"
   labels:
     role: "background-job"
-    job_type: {{ job_type }}
+    job_type: "{{ job_type }}"
 {% if oid %}
-    btrix.org: {{ oid }}
+    btrix.org: "{{ oid }}"
 {% endif %}
 {% if collection_id %}
-    btrix.collid: {{ collection_id }}
+    btrix.collid: "{{ collection_id }}"
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 300
   backoffLimit: 6
   {% if scale %}
   parallelism: {{ scale }}
@@ -41,18 +41,18 @@ spec:
 
       containers:
         - name: btrixbgjob
-          image: {{ backend_image }}
-          imagePullPolicy: {{ pull_policy }}
+          image: "{{ backend_image }}"
+          imagePullPolicy: "{{ pull_policy }}"
           env:
           - name: BG_JOB_TYPE
             value: {{ job_type }}
 
 {% if oid %}
           - name: OID
-            value: {{ oid }}
+            value: "{{ oid }}"
 {% endif %}
           - name: CRAWL_TYPE
-            value: {{ crawl_type }}
+            value: "{{ crawl_type }}"
 
 {% if crawl_id %}
           - name: CRAWL_ID
@@ -61,7 +61,7 @@ spec:
 
 {% if collection_id %}
           - name: COLLECTION_ID
-            value: {{ collection_id }}
+            value: "{{ collection_id }}"
 {% endif %}
 
           envFrom:

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -13,7 +13,7 @@ metadata:
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 300
+  ttlSecondsAfterFinished: 0
   backoffLimit: 6
   {% if scale %}
   parallelism: {{ scale }}

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -14,21 +14,21 @@ metadata:
 
 spec:
   ttlSecondsAfterFinished: 0
-  backoffLimit: 3
+  backoffLimit: 6
   {% if scale %}
   parallelism: {{ scale }}
   {% endif %}
+  podFailurePolicy:
+    rules:
+    - action: FailJob
+      onExitCodes:
+        containerName: btrixbgjob
+        operator: In
+        values: [2]
   template:
     spec:
       restartPolicy: Never
       priorityClassName: bg-job
-      podFailurePolicy:
-        rules:
-        - action: FailJob
-          onExitCodes:
-            containerName: btrixbgjob
-            operator: NotIn
-            values: [0]
       
       volumes:
         - name: ops-configs


### PR DESCRIPTION
Fixes #3570 

- Use `podFailurePolicy` to skip background job retries only on fatal errors, and ensure `podFailurePolicy` is in the right place in the kubernetes YAML manifest
- Add a new `IntEnum` for background job exit codes
- Add exit code for fatal errors that should skip retries via the backoffLimit and instead immediately fail the job (e.g. on configuration errors)
- Raise `backoffLimit` for background jobs to 6

The `background_job.yaml` template now validates with [kubeconform](https://github.com/yannh/kubeconform) after rendering the jinja2 template. To test this with kubeconform and [jinja2-cli](https://github.com/mattrobenolt/jinja2-cli)):

```sh
# install dependencies
brew install kubeconform
python -m pip install jinja2-cli

# render jinja2 template and pass to kubeconform
jinja2 chart/app-templates/background_job.yaml -D id="testid" -D job_type="example" -D oid="37b9f9f5-e922-4732-88f3-899dad70a3a9-dclzb" -D collection_id="19638c35-ee92-49ac-b7ee-b7689c500575" -D scale=2 -D crawl_type="manual" -D crawl_id="crawl-123" -D larger_resources=True -D backend_image="docker.io/webrecorder/browsertrix-crawler:latest" -D pull_policy="IfNotPresent" | kubeconform -strict
```

We should look at fixing our other templates as well and adding CI to test their validity, but I think that's a better done separately to not block this PR so tracking that in https://github.com/webrecorder/browsertrix/issues/3592.