### PR TITLE
fix: Select correct day of week

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -1105,6 +1105,11 @@ export class WorkflowEditor extends BtrixElement {
           value=${this.formState.seedListFormat}
           name="seedListFormat"
           size="small"
+          @sl-change=${(e: Event) =>
+            this.updateFormState({
+              seedListFormat: (e.target as SlRadioGroup)
+                .value as SeedListFormat,
+            })}
         >
           <sl-radio-button value=${SeedListFormat.JSON}>
             ${msg("Enter URLs")}
@@ -3339,7 +3344,6 @@ https://archiveweb.page/images/${"logo.svg"}`}
         value = (elem as SlCheckbox).checked;
         break;
       case "sl-textarea":
-      case "sl-radio-group":
         value = elem.value;
         break;
       case "sl-input": {

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -241,9 +241,9 @@ export function getUTCSchedule({
   localDate.setHours(+hour + periodOffset);
   localDate.setMinutes(+minute);
 
-  if (interval === "monthly" && dayOfMonth) {
+  if (interval === "monthly" && dayOfMonth !== undefined) {
     localDate.setDate(dayOfMonth);
-  } else if (interval == "weekly" && dayOfWeek) {
+  } else if (interval == "weekly" && dayOfWeek !== undefined) {
     localDate.setDate(localDate.getDate() + dayOfWeek - localDate.getDay());
   }
 


### PR DESCRIPTION
## Changes

Fixes incorrect day of week being selected due to form state being updated multiple times, with the string value overriding the numeric value.

## Manual testing

1. Log in as crawler
2. Go to New Workflow > Scheduling
3. Select "Run on recurring basis"
4. Select weekly frequency
5. Select different days of week. Verify that help text updates as expected