### PR TITLE
fix: Better handling of aborted thumbnail signal

### DIFF
--- a/frontend/src/features/collections/select-collection-thumbnail.ts
+++ b/frontend/src/features/collections/select-collection-thumbnail.ts
@@ -294,6 +294,8 @@ export class SelectCollectionThumbnail extends BtrixElement {
   }
 
   disconnectedCallback(): void {
+    super.disconnectedCallback();
+
     for (const screenshot of this.#screenshots.values()) {
       void screenshot.url.then((url) =>
         url ? URL.revokeObjectURL(url) : null,

--- a/frontend/src/features/collections/select-collection-thumbnail.ts
+++ b/frontend/src/features/collections/select-collection-thumbnail.ts
@@ -203,7 +203,12 @@ export class SelectCollectionThumbnail extends BtrixElement {
 
           thumbnail = {
             blob,
-            url: blob.then((v) => (v ? URL.createObjectURL(v) : undefined)),
+            url: blob
+              .then((v) => (v ? URL.createObjectURL(v) : undefined))
+              .catch((err) => {
+                console.debug(err);
+                return undefined;
+              }),
           };
 
           // - Cache blob to use as upload payload
@@ -296,11 +301,12 @@ export class SelectCollectionThumbnail extends BtrixElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    for (const screenshot of this.#screenshots.values()) {
-      void screenshot.url.then((url) =>
-        url ? URL.revokeObjectURL(url) : null,
-      );
-    }
+    void Promise.allSettled(
+      Array.from(this.#screenshots.values()).map(
+        ({ url }) =>
+          void url.then((url) => (url ? URL.revokeObjectURL(url) : null)),
+      ),
+    );
   }
 
   render() {

--- a/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
+++ b/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
@@ -22,12 +22,23 @@ export const getThumbnailBlob = async (
     console.debug("no rwp");
     return;
   }
-  const resp = await rwp.shadowRoot
-    ?.querySelector("iframe")
-    ?.contentWindow?.fetch(
-      `/replay/w/${collectionId}/${formatRwpTimestamp(timestamp)}id_/urn:thumbnail:${url}`,
-      { signal },
-    );
+
+  let resp: Response | undefined = undefined;
+
+  try {
+    resp = await rwp.shadowRoot
+      ?.querySelector("iframe")
+      ?.contentWindow?.fetch(
+        `/replay/w/${collectionId}/${formatRwpTimestamp(timestamp)}id_/urn:thumbnail:${url}`,
+        { signal },
+      );
+  } catch (err) {
+    if (signal.aborted || resp) {
+      return;
+    }
+
+    throw err;
+  }
 
   if (resp?.status === 200) {
     return await resp.blob();

--- a/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
+++ b/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
@@ -22,7 +22,6 @@ export const getThumbnailBlob = async (
     console.debug("no rwp");
     return;
   }
-
   const resp = await rwp.shadowRoot
     ?.querySelector("iframe")
     ?.contentWindow?.fetch(

--- a/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
+++ b/frontend/src/pages/org/collection-detail/utils/getThumbnailBlob.ts
@@ -23,22 +23,12 @@ export const getThumbnailBlob = async (
     return;
   }
 
-  let resp: Response | undefined = undefined;
-
-  try {
-    resp = await rwp.shadowRoot
-      ?.querySelector("iframe")
-      ?.contentWindow?.fetch(
-        `/replay/w/${collectionId}/${formatRwpTimestamp(timestamp)}id_/urn:thumbnail:${url}`,
-        { signal },
-      );
-  } catch (err) {
-    if (signal.aborted || resp) {
-      return;
-    }
-
-    throw err;
-  }
+  const resp = await rwp.shadowRoot
+    ?.querySelector("iframe")
+    ?.contentWindow?.fetch(
+      `/replay/w/${collectionId}/${formatRwpTimestamp(timestamp)}id_/urn:thumbnail:${url}`,
+      { signal },
+    );
 
   if (resp?.status === 200) {
     return await resp.blob();


### PR DESCRIPTION
Follows https://github.com/webrecorder/browsertrix/pull/3479

## Changes

Prevents the collection detail page from throwing an error if the request to fetch a thumbnail from replay is aborted. No specific user facing changes, but a dev annoyance since the error overlay pops up if you go back in your browser history before the thumbnails finish loading.