### PR TITLE
attempt to ensure metacontroller finalizers always run

### DIFF
--- a/backend/test_nightly/test_delete_crawls.py
+++ b/backend/test_nightly/test_delete_crawls.py
@@ -104,7 +104,7 @@ def test_delete_replica_job_run(admin_auth_headers, default_org_id):
         )
         assert r.status_code == 200
         jobs = r.json()["items"]
-        if len(jobs) === 0:
+        if len(jobs) == 0:
             attempts += 1
             time.sleep(10)
             continue

--- a/backend/test_nightly/test_delete_crawls.py
+++ b/backend/test_nightly/test_delete_crawls.py
@@ -94,12 +94,25 @@ def test_delete_replica_job_run(admin_auth_headers, default_org_id):
     time.sleep(20)
 
     # Verify delete replica job was successful
-    r = requests.get(
-        f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=delete-replica",
-        headers=admin_auth_headers,
-    )
-    assert r.status_code == 200
-    latest_job = r.json()["items"][0]
+    latest_job = None
+
+    attempts = 0
+    while attempts < 5:
+        r = requests.get(
+            f"{API_PREFIX}/orgs/{default_org_id}/jobs?sortBy=started&sortDirection=-1&jobType=delete-replica",
+            headers=admin_auth_headers,
+        )
+        assert r.status_code == 200
+        jobs = r.json()["items"]
+        if len(jobs) === 0:
+            attempts += 1
+            time.sleep(10)
+            continue
+
+        latest_job = jobs[0]
+        break
+
+    assert latest_job
     assert latest_job["type"] == "delete-replica"
     job_id = latest_job["id"]
 

--- a/chart/app-templates/background_cron_job.yaml
+++ b/chart/app-templates/background_cron_job.yaml
@@ -15,6 +15,8 @@ spec:
 
   jobTemplate:
     metadata:
+      finalizers:
+        - metacontroller.io/decoratorcontroller-background-job-operator
       labels:
         role: "background-job"
         job_type: {{ job_type }}

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -15,7 +15,7 @@ metadata:
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 30
+  ttlSecondsAfterFinished: 10
   backoffLimit: 3
   {% if scale %}
   parallelism: {{ scale }}

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -15,7 +15,7 @@ metadata:
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 1
+  ttlSecondsAfterFinished: 0
   backoffLimit: 3
   {% if scale %}
   parallelism: {{ scale }}

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ id }}"
+  finalizers:
+    - metacontroller.io/decoratorcontroller-background-job-operator
   labels:
     role: "background-job"
     job_type: {{ job_type }}
@@ -13,7 +15,7 @@ metadata:
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
   backoffLimit: 3
   {% if scale %}
   parallelism: {{ scale }}

--- a/chart/app-templates/background_job.yaml
+++ b/chart/app-templates/background_job.yaml
@@ -15,7 +15,7 @@ metadata:
 {% endif %}
 
 spec:
-  ttlSecondsAfterFinished: 10
+  ttlSecondsAfterFinished: 1
   backoffLimit: 3
   {% if scale %}
   parallelism: {{ scale }}

--- a/chart/app-templates/coll_index.yaml
+++ b/chart/app-templates/coll_index.yaml
@@ -2,6 +2,8 @@ apiVersion: btrix.cloud/v1
 kind: CollIndex
 metadata:
   name: collindex-{{ id }}
+  finalizers:
+    - metacontroller.io/compositecontroller-collindexes-operator
   labels:
     role: "collindex"
     oid: {{ oid }}

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -2,6 +2,8 @@ apiVersion: btrix.cloud/v1
 kind: CrawlJob
 metadata:
   name: crawljob-{{ id }}
+  finalizers:
+    - metacontroller.io/compositecontroller-crawljobs-operator
   labels:
     crawl: "{{ id }}"
     role: {{ "qa-job" if qa_source else "job" }}

--- a/chart/app-templates/replica_deletion_cron_job.yaml
+++ b/chart/app-templates/replica_deletion_cron_job.yaml
@@ -16,6 +16,8 @@ spec:
 
   jobTemplate:
     metadata:
+      finalizers:
+        - metacontroller.io/decoratorcontroller-background-job-operator
       labels:
         role: "background-job"
         job_type: {{ job_type }}

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -10,7 +10,7 @@ metadata:
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 10
+  ttlSecondsAfterFinished: 0
   backoffLimit: 3
   template:
     spec:

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -2,13 +2,15 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ id }}"
+  finalizers:
+    - metacontroller.io/decoratorcontroller-background-job-operator
   labels:
     role: "background-job"
     job_type: {{ job_type }}
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
   backoffLimit: 3
   template:
     spec:

--- a/chart/app-templates/replica_job.yaml
+++ b/chart/app-templates/replica_job.yaml
@@ -10,7 +10,7 @@ metadata:
     btrix.org: {{ oid }}
 
 spec:
-  ttlSecondsAfterFinished: 30
+  ttlSecondsAfterFinished: 10
   backoffLimit: 3
   template:
     spec:


### PR DESCRIPTION
Looking into this issue more, it seems the ttlSecondsAfterFinished set to 0 is likely the main culprit for finalizers being skipped for these resources, as the job is cleaned up right away. However, to guarantee the finalizers are always run, they should also declared as part of the object metadata at creation time for the resources that have these hooks.

This PR:
- set ttlSecondsAfterFinished to 10 for replica jobs, 1 for other background jobs (to avoid breaking tests which wait for these jobs to be finalized)
- explicitly declares the appropriate metacontroller finalizer hook on each resource that has a finalize hook (crawljob, collindex, background-job) at resource creation time

Should fix #3365 

