### PR TITLE
Generate seed file presigned URL in crawl operator, update prior to expiry

### DIFF
--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -490,7 +490,7 @@ class CollectionOps:
         thumbnail = result.get("thumbnail")
         if thumbnail:
             image_file = UserFile(**thumbnail)
-            result["thumbnail"] = await image_file.get_public_file_out(
+            result["thumbnail"], _ = await image_file.get_public_file_out(
                 org, self.storage_ops, headers
             )
 
@@ -513,7 +513,7 @@ class CollectionOps:
             raise HTTPException(status_code=404, detail="thumbnail_not_found")
 
         image_file = UserFile(**thumbnail)
-        image_file_out = await image_file.get_public_file_out(
+        image_file_out, _ = await image_file.get_public_file_out(
             org, self.storage_ops, headers
         )
 
@@ -630,7 +630,7 @@ class CollectionOps:
                 image_file = UserFile(**thumbnail)
 
                 if public_colls_out:
-                    res["thumbnail"] = await image_file.get_public_file_out(
+                    res["thumbnail"], _ = await image_file.get_public_file_out(
                         org, self.storage_ops, headers
                     )
                 else:

--- a/backend/btrixcloud/colls.py
+++ b/backend/btrixcloud/colls.py
@@ -442,7 +442,7 @@ class CollectionOps:
         thumbnail = result.get("thumbnail")
         if thumbnail:
             image_file = UserFile(**thumbnail)
-            result["thumbnail"] = await image_file.get_file_out(
+            result["thumbnail"], _ = await image_file.get_file_out(
                 org, self.storage_ops, headers
             )
 
@@ -634,7 +634,7 @@ class CollectionOps:
                         org, self.storage_ops, headers
                     )
                 else:
-                    res["thumbnail"] = await image_file.get_file_out(
+                    res["thumbnail"], _ = await image_file.get_file_out(
                         org, self.storage_ops, headers
                     )
 

--- a/backend/btrixcloud/crawlconfigs.py
+++ b/backend/btrixcloud/crawlconfigs.py
@@ -1379,7 +1379,6 @@ class CrawlConfigOps:
             crawlconfig.crawlFilenameTemplate or self.default_filename_template
         )
 
-        seed_file_url = ""
         if crawlconfig.config.seedFileId:
             crawler_image = self.get_channel_crawler_image(crawlconfig.crawlerChannel)
             if (
@@ -1393,11 +1392,6 @@ class CrawlConfigOps:
                     status_code=400, detail="seed_file_not_supported_by_crawler"
                 )
 
-            seed_file_out = await self.file_ops.get_seed_file_out(
-                crawlconfig.config.seedFileId, org
-            )
-            seed_file_url = seed_file_out.path
-
         try:
             crawl_id = await self.crawl_manager.create_crawl_job(
                 crawlconfig,
@@ -1408,7 +1402,9 @@ class CrawlConfigOps:
                 profile_filename=profile_filename or "",
                 profileid=str(crawlconfig.profileid) if crawlconfig.profileid else "",
                 is_single_page=self.is_single_page(crawlconfig.config),
-                seed_file_url=seed_file_url,
+                seed_file_id=str(crawlconfig.config.seedFileId)
+                if crawlconfig.config.seedFileId
+                else "",
             )
             await self.add_new_crawl(crawl_id, crawlconfig, user, org, manual=True)
             return crawl_id

--- a/backend/btrixcloud/crawlmanager.py
+++ b/backend/btrixcloud/crawlmanager.py
@@ -423,7 +423,7 @@ class CrawlManager(K8sAPI):
         profile_filename: str,
         profileid: str,
         is_single_page: bool,
-        seed_file_url: str,
+        seed_file_id: str,
     ) -> str:
         """create new crawl job from config"""
         cid = str(crawlconfig.id)
@@ -453,7 +453,7 @@ class CrawlManager(K8sAPI):
                 str(crawlconfig.dedupeCollId) if crawlconfig.dedupeCollId else ""
             ),
             is_single_page=is_single_page,
-            seed_file_url=seed_file_url,
+            seed_file_id=seed_file_id,
         )
 
     async def reload_running_crawl_config(self, crawl_id: str):

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 from collections.abc import AsyncGenerator, Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -111,7 +111,7 @@ class FileUploadOps:
         type_: str | None = None,
         headers: dict | None = None,
         force_update_presigned: bool = False,
-    ) -> SeedFileOut:
+    ) -> tuple[SeedFileOut, datetime]:
         """Get file output model by UUID"""
         user_file = await self.get_seed_file(file_id, org, type_)
         return await user_file.get_file_out(
@@ -181,7 +181,7 @@ class FileUploadOps:
         user_files = []
         for res in items:
             file_ = SeedFile.from_dict(res)
-            file_out = await file_.get_file_out(org, self.storage_ops, headers)
+            file_out, _ = await file_.get_file_out(org, self.storage_ops, headers)
             user_files.append(file_out)
 
         return user_files, total
@@ -314,7 +314,7 @@ class FileUploadOps:
         first_seed = ""
         seed_count = 0
 
-        file_url = await file_obj.get_absolute_presigned_url(
+        file_url, _ = await file_obj.get_absolute_presigned_url(
             org, self.storage_ops, None
         )
 
@@ -530,7 +530,10 @@ def init_file_uploads_api(
     async def get_seed_file(
         file_id: UUID, request: Request, org: Organization = Depends(org_viewer_dep)
     ):
-        return await ops.get_seed_file_out(file_id, org, headers=dict(request.headers))
+        seed_file, _ = await ops.get_seed_file_out(
+            file_id, org, headers=dict(request.headers)
+        )
+        return seed_file
 
     @router.delete("/{file_id}", response_model=SuccessResponse)
     async def delete_user_file(

--- a/backend/btrixcloud/file_uploads.py
+++ b/backend/btrixcloud/file_uploads.py
@@ -110,10 +110,13 @@ class FileUploadOps:
         org: Organization | None = None,
         type_: str | None = None,
         headers: dict | None = None,
+        force_update_presigned: bool = False,
     ) -> SeedFileOut:
         """Get file output model by UUID"""
         user_file = await self.get_seed_file(file_id, org, type_)
-        return await user_file.get_file_out(org, self.storage_ops, headers)
+        return await user_file.get_file_out(
+            org, self.storage_ops, headers, force_update_presigned
+        )
 
     async def list_seed_files(
         self,

--- a/backend/btrixcloud/k8sapi.py
+++ b/backend/btrixcloud/k8sapi.py
@@ -119,7 +119,7 @@ class K8sAPI:
         proxy_id: str = "",
         dedupe_coll_id: str = "",
         is_single_page: bool = False,
-        seed_file_url: str = "",
+        seed_file_id: str = "",
     ):
         """load job template from yaml"""
         if not crawl_id:
@@ -147,7 +147,7 @@ class K8sAPI:
             "proxy_id": proxy_id,
             "dedupe_coll_id": dedupe_coll_id,
             "is_single_page": "1" if is_single_page else "0",
-            "seed_file_url": seed_file_url,
+            "seed_file_id": seed_file_id,
         }
 
         data = self.templates.env.get_template("crawl_job.yaml").render(params)
@@ -174,7 +174,7 @@ class K8sAPI:
         proxy_id: str = "",
         dedupe_coll_id: str = "",
         is_single_page: bool = False,
-        seed_file_url: str = "",
+        seed_file_id: str = "",
     ) -> str:
         """load and init crawl job via k8s api"""
         crawl_id, data = self.new_crawl_job_yaml(
@@ -197,7 +197,7 @@ class K8sAPI:
             proxy_id=proxy_id,
             dedupe_coll_id=dedupe_coll_id,
             is_single_page=is_single_page,
-            seed_file_url=seed_file_url,
+            seed_file_id=seed_file_id,
         )
 
         # create job directly

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1425,15 +1425,18 @@ class UserFile(BaseFile):
 
     async def get_public_file_out(
         self, org, storage_ops, headers: dict | None = None
-    ) -> PublicUserFileOut:
+    ) -> tuple[PublicUserFileOut, datetime]:
         """Get PublicUserFileOut with new presigned url"""
+        path, expire_at = await self.get_absolute_presigned_url(
+            org, storage_ops, headers
+        )
         return PublicUserFileOut(
             name=self.filename,
-            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
+            path=path,
             hash=self.hash,
             size=self.size,
             mime=self.mime,
-        )
+        ), expire_at
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1391,10 +1391,14 @@ class UserFile(BaseFile):
 
     async def get_absolute_presigned_url(
         self, org, storage_ops, headers: dict | None, force_update: bool = False
-    ) -> str:
+    ) -> tuple[str, datetime]:
         """Get presigned URL as absolute URL"""
-        presigned_url, _ = await storage_ops.get_presigned_url(org, self, force_update)
-        return storage_ops.resolve_relative_access_path(presigned_url, headers) or ""
+        presigned_url, expire_at = await storage_ops.get_presigned_url(
+            org, self, force_update
+        )
+        return storage_ops.resolve_relative_access_path(
+            presigned_url, headers
+        ) or "", expire_at
 
     async def get_file_out(
         self,
@@ -1402,13 +1406,14 @@ class UserFile(BaseFile):
         storage_ops,
         headers: dict | None = None,
         force_update_presigned: bool = False,
-    ) -> UserFileOut:
+    ) -> tuple[UserFileOut, datetime]:
         """Get UserFileOut with new presigned url"""
+        path, expire_at = await self.get_absolute_presigned_url(
+            org, storage_ops, headers, force_update_presigned
+        )
         return UserFileOut(
             name=self.filename,
-            path=await self.get_absolute_presigned_url(
-                org, storage_ops, headers, force_update_presigned
-            ),
+            path=path,
             hash=self.hash,
             size=self.size,
             originalFilename=self.originalFilename,
@@ -1416,7 +1421,7 @@ class UserFile(BaseFile):
             userid=self.userid,
             userName=self.userName,
             created=self.created,
-        )
+        ), expire_at
 
     async def get_public_file_out(
         self, org, storage_ops, headers: dict | None = None
@@ -1503,13 +1508,14 @@ class SeedFile(UserFile, BaseMongoModel):
         storage_ops,
         headers: dict | None = None,
         force_update_presigned: bool = False,
-    ) -> SeedFileOut:
+    ) -> tuple[SeedFileOut, datetime]:
         """Get SeedFileOut with new presigned url"""
+        path, expire_at = await self.get_absolute_presigned_url(
+            org, storage_ops, headers, force_update_presigned
+        )
         return SeedFileOut(
             name=self.filename,
-            path=await self.get_absolute_presigned_url(
-                org, storage_ops, headers, force_update_presigned
-            ),
+            path=path,
             hash=self.hash,
             size=self.size,
             originalFilename=self.originalFilename,
@@ -1522,7 +1528,7 @@ class SeedFile(UserFile, BaseMongoModel):
             type=self.type,
             firstSeed=self.firstSeed,
             seedCount=self.seedCount,
-        )
+        ), expire_at
 
 
 # ============================================================================

--- a/backend/btrixcloud/models.py
+++ b/backend/btrixcloud/models.py
@@ -1390,19 +1390,25 @@ class UserFile(BaseFile):
     created: datetime
 
     async def get_absolute_presigned_url(
-        self, org, storage_ops, headers: dict | None
+        self, org, storage_ops, headers: dict | None, force_update: bool = False
     ) -> str:
         """Get presigned URL as absolute URL"""
-        presigned_url, _ = await storage_ops.get_presigned_url(org, self)
+        presigned_url, _ = await storage_ops.get_presigned_url(org, self, force_update)
         return storage_ops.resolve_relative_access_path(presigned_url, headers) or ""
 
     async def get_file_out(
-        self, org, storage_ops, headers: dict | None = None
+        self,
+        org,
+        storage_ops,
+        headers: dict | None = None,
+        force_update_presigned: bool = False,
     ) -> UserFileOut:
         """Get UserFileOut with new presigned url"""
         return UserFileOut(
             name=self.filename,
-            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
+            path=await self.get_absolute_presigned_url(
+                org, storage_ops, headers, force_update_presigned
+            ),
             hash=self.hash,
             size=self.size,
             originalFilename=self.originalFilename,
@@ -1492,12 +1498,18 @@ class SeedFile(UserFile, BaseMongoModel):
     seedCount: int | None = None
 
     async def get_file_out(
-        self, org, storage_ops, headers: dict | None = None
+        self,
+        org,
+        storage_ops,
+        headers: dict | None = None,
+        force_update_presigned: bool = False,
     ) -> SeedFileOut:
         """Get SeedFileOut with new presigned url"""
         return SeedFileOut(
             name=self.filename,
-            path=await self.get_absolute_presigned_url(org, storage_ops, headers),
+            path=await self.get_absolute_presigned_url(
+                org, storage_ops, headers, force_update_presigned
+            ),
             hash=self.hash,
             size=self.size,
             originalFilename=self.originalFilename,

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -181,6 +181,7 @@ class CrawlOperator(BaseOperator):
 
         status = CrawlStatus(**data.parent.get("status", {}))
         status.last_state = status.state
+        status.updateSeedFilePresigned = False
 
         spec: dict[str, str] = data.parent.get(
             "spec", {}
@@ -461,9 +462,9 @@ class CrawlOperator(BaseOperator):
 
         if spec.get("restartTime") != status.restartTime:
             # pylint: disable=invalid-name
-            # TODO: Is this our other hook for when we want to regen seed file presigned URL?
             status.restartTime = spec.get("restartTime")
             status.resync_after = self.fast_retry_secs
+            status.updateSeedFilePresigned = True
             params["force_restart"] = True
         else:
             params["force_restart"] = False
@@ -472,9 +473,9 @@ class CrawlOperator(BaseOperator):
             spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
         )
         # Always update if seed file to generate new presigned URL
-        # TODO: This isn't quite right, only want to do it if we're restarting
-        # Or maybe if a certain amount of time has elapsed?
-        config_update_needed = config_update_needed or bool(crawl.seed_file_id)
+        config_update_needed = config_update_needed or (
+            bool(crawl.seed_file_id) and status.updateSeedFilePresigned
+        )
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 
         children.extend(
@@ -1952,11 +1953,11 @@ class CrawlOperator(BaseOperator):
 
         # check if no longer paused, clear paused stopping state
         if status.stopReason in PAUSED_STATES and not crawl.paused_at:
-            # TODO: Set status field for this iteration so that we know to re-gen
-            # configmap and presigned URL?
-            # Or is there somewhere better, where we can catch all restarts as well?
             status.stopReason = None
             status.stopping = False
+            # Make sure we generate new presigned URL for seed file when loading
+            # crawl configmap, as old one may have expired
+            status.updateSeedFilePresigned = True
             # should have already been removed, just in case
             await redis.delete(f"{crawl.id}:paused")
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -229,7 +229,7 @@ class CrawlOperator(BaseOperator):
             scheduled=spec.get("manual") != "1",
             qa_source_crawl_id=spec.get("qaSourceCrawlId"),
             is_single_page=spec.get("isSinglePage") == "1",
-            seed_file_url=spec.get("seedFileUrl", ""),
+            seed_file_id=spec.get("seedFileId", ""),
         )
 
         # if finalizing, crawl is being deleted
@@ -470,6 +470,8 @@ class CrawlOperator(BaseOperator):
         config_update_needed = (
             spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
         )
+        # Always update if seed file to generate new presigned URL
+        config_update_needed = config_update_needed or bool(crawl.seed_file_id)
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 
         children.extend(
@@ -591,8 +593,11 @@ class CrawlOperator(BaseOperator):
             raw_config["behaviors"], crawler_image
         )
 
-        if crawl.seed_file_url:
-            raw_config["seedFile"] = crawl.seed_file_url
+        if crawl.seed_file_id:
+            seed_file_out = await self.file_ops.get_seed_file_out(
+                UUID(crawl.seed_file_id), crawl.org, force_update_presigned=True
+            )
+            raw_config["seedFile"] = seed_file_out.path
         raw_config.pop("seedFileId", None)
 
         params["config"] = json.dumps(raw_config)

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -181,7 +181,6 @@ class CrawlOperator(BaseOperator):
 
         status = CrawlStatus(**data.parent.get("status", {}))
         status.last_state = status.state
-        status.update_seed_file_presigned = False
 
         spec: dict[str, str] = data.parent.get(
             "spec", {}
@@ -471,15 +470,20 @@ class CrawlOperator(BaseOperator):
         config_update_needed = (
             spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
         )
-        # Always update if seed file to generate new presigned URL
+
+        # Always update if seed file is used and presigned url has already
+        # expired or will expire within a day
         config_update_needed = config_update_needed or (
-            bool(crawl.seed_file_id) and status.update_seed_file_presigned
+            bool(crawl.seed_file_id)
+            and status.seed_file_presigned_expiry is not None
+            and (status.seed_file_presigned_expiry <= (dt_now() + timedelta(days=1)))
         )
+
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 
         children.extend(
             await self._load_crawl_configmap(
-                crawl, data.children, params, config_update_needed
+                crawl, data.children, params, status, config_update_needed
             )
         )
 
@@ -567,7 +571,12 @@ class CrawlOperator(BaseOperator):
         return behaviors
 
     async def _load_crawl_configmap(
-        self, crawl: CrawlSpec, children, params, config_update_needed: bool
+        self,
+        crawl: CrawlSpec,
+        children,
+        params,
+        status: CrawlStatus,
+        config_update_needed: bool,
     ):
         name = f"crawl-config-{crawl.id}"
 
@@ -597,8 +606,15 @@ class CrawlOperator(BaseOperator):
         )
 
         if crawl.seed_file_id:
-            seed_file_out = await self.file_ops.get_seed_file_out(
+            seed_file_out, expire_at = await self.file_ops.get_seed_file_out(
                 UUID(crawl.seed_file_id), crawl.org, force_update_presigned=True
+            )
+            status.seed_file_presigned_expiry = expire_at
+            logger.debug(
+                "seed_file_presigned_url_generated",
+                crawl_id=crawl.id,
+                seed_file_id=crawl.seed_file_id,
+                expire_at=expire_at,
             )
             raw_config["seedFile"] = seed_file_out.path
         raw_config.pop("seedFileId", None)
@@ -1166,7 +1182,6 @@ class CrawlOperator(BaseOperator):
             # skip if no newly exited pods
             if status.anyCrawlPodNewExit:
                 await self.log_crashes(crawl.id, status.podStatus, redis)
-                status.update_seed_file_presigned = True
 
             if not crawler_running or not redis:
                 # if either crawler is not running or redis is inaccessible
@@ -1955,9 +1970,6 @@ class CrawlOperator(BaseOperator):
         if status.stopReason in PAUSED_STATES and not crawl.paused_at:
             status.stopReason = None
             status.stopping = False
-            # Make sure we generate new presigned URL for seed file when loading
-            # crawl configmap, as old one may have expired
-            status.update_seed_file_presigned = True
             # should have already been removed, just in case
             await redis.delete(f"{crawl.id}:paused")
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -181,7 +181,7 @@ class CrawlOperator(BaseOperator):
 
         status = CrawlStatus(**data.parent.get("status", {}))
         status.last_state = status.state
-        status.updateSeedFilePresigned = False
+        status.update_seed_file_presigned = False
 
         spec: dict[str, str] = data.parent.get(
             "spec", {}
@@ -464,7 +464,7 @@ class CrawlOperator(BaseOperator):
             # pylint: disable=invalid-name
             status.restartTime = spec.get("restartTime")
             status.resync_after = self.fast_retry_secs
-            status.updateSeedFilePresigned = True
+            status.update_seed_file_presigned = True
             params["force_restart"] = True
         else:
             params["force_restart"] = False
@@ -474,7 +474,7 @@ class CrawlOperator(BaseOperator):
         )
         # Always update if seed file to generate new presigned URL
         config_update_needed = config_update_needed or (
-            bool(crawl.seed_file_id) and status.updateSeedFilePresigned
+            bool(crawl.seed_file_id) and status.update_seed_file_presigned
         )
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 
@@ -1957,7 +1957,7 @@ class CrawlOperator(BaseOperator):
             status.stopping = False
             # Make sure we generate new presigned URL for seed file when loading
             # crawl configmap, as old one may have expired
-            status.updateSeedFilePresigned = True
+            status.update_seed_file_presigned = True
             # should have already been removed, just in case
             await redis.delete(f"{crawl.id}:paused")
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -471,13 +471,18 @@ class CrawlOperator(BaseOperator):
             spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
         )
 
-        # Always update if seed file is used and presigned url has already
-        # expired or will expire within a day
-        config_update_needed = config_update_needed or (
-            bool(crawl.seed_file_id)
-            and status.seed_file_presigned_expiry is not None
-            and (status.seed_file_presigned_expiry <= (dt_now() + timedelta(days=1)))
+        # Update config to refresh seed file presigned url if it has
+        # already expired or will within the next hour
+        seed_file_presigned_update_needed = bool(crawl.seed_file_id) and (
+            status.seed_file_presigned_expiry is None
+            or (status.seed_file_presigned_expiry <= (dt_now() + timedelta(hours=1)))
         )
+        if seed_file_presigned_update_needed:
+            logger.debug(
+                "seed_file_presigned_url_update_needed",
+                expire_at=status.seed_file_presigned_expiry,
+            )
+        config_update_needed = config_update_needed or seed_file_presigned_update_needed
 
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -464,7 +464,6 @@ class CrawlOperator(BaseOperator):
             # pylint: disable=invalid-name
             status.restartTime = spec.get("restartTime")
             status.resync_after = self.fast_retry_secs
-            status.update_seed_file_presigned = True
             params["force_restart"] = True
         else:
             params["force_restart"] = False
@@ -1167,6 +1166,7 @@ class CrawlOperator(BaseOperator):
             # skip if no newly exited pods
             if status.anyCrawlPodNewExit:
                 await self.log_crashes(crawl.id, status.podStatus, redis)
+                status.update_seed_file_presigned = True
 
             if not crawler_running or not redis:
                 # if either crawler is not running or redis is inaccessible

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -618,6 +618,7 @@ class CrawlOperator(BaseOperator):
             logger.debug(
                 "seed_file_presigned_url_generated",
                 crawl_id=crawl.id,
+                seed_file_url=seed_file_out.path,
                 seed_file_id=crawl.seed_file_id,
                 expire_at=expire_at,
             )

--- a/backend/btrixcloud/operator/crawls.py
+++ b/backend/btrixcloud/operator/crawls.py
@@ -461,6 +461,7 @@ class CrawlOperator(BaseOperator):
 
         if spec.get("restartTime") != status.restartTime:
             # pylint: disable=invalid-name
+            # TODO: Is this our other hook for when we want to regen seed file presigned URL?
             status.restartTime = spec.get("restartTime")
             status.resync_after = self.fast_retry_secs
             params["force_restart"] = True
@@ -471,6 +472,8 @@ class CrawlOperator(BaseOperator):
             spec.get("lastConfigUpdate", "") != status.lastConfigUpdate
         )
         # Always update if seed file to generate new presigned URL
+        # TODO: This isn't quite right, only want to do it if we're restarting
+        # Or maybe if a certain amount of time has elapsed?
         config_update_needed = config_update_needed or bool(crawl.seed_file_id)
         status.lastConfigUpdate = spec.get("lastConfigUpdate", "")
 
@@ -1949,6 +1952,9 @@ class CrawlOperator(BaseOperator):
 
         # check if no longer paused, clear paused stopping state
         if status.stopReason in PAUSED_STATES and not crawl.paused_at:
+            # TODO: Set status field for this iteration so that we know to re-gen
+            # configmap and presigned URL?
+            # Or is there somewhere better, where we can catch all restarts as well?
             status.stopReason = None
             status.stopping = False
             # should have already been removed, just in case

--- a/backend/btrixcloud/operator/cronjobs.py
+++ b/backend/btrixcloud/operator/cronjobs.py
@@ -172,14 +172,6 @@ class CronJobOperator(BaseOperator):
         else:
             profile_filename = ""
 
-        if crawlconfig.config.seedFileId:
-            seed_file = await self.file_ops.get_seed_file_out(
-                crawlconfig.config.seedFileId, org
-            )
-            seed_file_url = seed_file.path
-        else:
-            seed_file_url = ""
-
         crawl_id, crawljob = self.k8s.new_crawl_job_yaml(
             cid=str(cid),
             userid=str(userid),
@@ -201,7 +193,9 @@ class CronJobOperator(BaseOperator):
                 str(crawlconfig.dedupeCollId) if crawlconfig.dedupeCollId else ""
             ),
             is_single_page=self.crawl_config_ops.is_single_page(crawlconfig.config),
-            seed_file_url=seed_file_url,
+            seed_file_id=str(crawlconfig.config.seedFileId)
+            if crawlconfig.config.seedFileId
+            else "",
         )
 
         return MCDecoratorSyncResponse(attachments=list(yaml.safe_load_all(crawljob)))

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -291,5 +291,5 @@ class CrawlStatus(BaseModel):
     # last state
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)
 
-    # if we need to generate new seed file presigned url (e.g. on restart or resume)
-    update_seed_file_presigned: bool = False
+    # expiry time for seed file presigned url
+    seed_file_presigned_expiry: datetime | None = None

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -292,4 +292,4 @@ class CrawlStatus(BaseModel):
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)
 
     # if we need to generate new seed file presigned url (e.g. on restart or resume)
-    updateSeedFilePresigned: bool = False
+    update_seed_file_presigned: bool = False

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -101,7 +101,7 @@ class CrawlSpec(BaseModel):
     profileid: str | None = None
     dedupe_coll_id: str | None = None
     is_single_page: bool = False
-    seed_file_url: str | None = ""
+    seed_file_id: str | None = ""
 
     @property
     def db_crawl_id(self) -> str:

--- a/backend/btrixcloud/operator/models.py
+++ b/backend/btrixcloud/operator/models.py
@@ -290,3 +290,6 @@ class CrawlStatus(BaseModel):
 
     # last state
     last_state: TYPE_ALL_CRAWL_STATES = Field(default="starting", exclude=True)
+
+    # if we need to generate new seed file presigned url (e.g. on restart or resume)
+    updateSeedFilePresigned: bool = False

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -508,6 +508,12 @@ class StorageOps:
     ) -> tuple[str, datetime]:
         """generate pre-signed url for crawl file"""
 
+        logger.debug(
+            "generating_presigned_url",
+            filename=crawlfile.filename,
+            force_update=force_update,
+        )
+
         res = None
         if not force_update:
             res = await self.presigned_urls.find_one({"_id": crawlfile.filename})

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -508,12 +508,6 @@ class StorageOps:
     ) -> tuple[str, datetime]:
         """generate pre-signed url for crawl file"""
 
-        logger.debug(
-            "generating_presigned_url",
-            target_filename=crawlfile.filename,
-            force_update=force_update,
-        )
-
         res = None
         if not force_update:
             res = await self.presigned_urls.find_one({"_id": crawlfile.filename})

--- a/backend/btrixcloud/storages.py
+++ b/backend/btrixcloud/storages.py
@@ -510,7 +510,7 @@ class StorageOps:
 
         logger.debug(
             "generating_presigned_url",
-            filename=crawlfile.filename,
+            target_filename=crawlfile.filename,
             force_update=force_update,
         )
 

--- a/chart/app-templates/crawl_job.yaml
+++ b/chart/app-templates/crawl_job.yaml
@@ -47,4 +47,4 @@ spec:
 
   isSinglePage: "{{ is_single_page }}"
 
-  seedFileUrl: "{{ seed_file_url }}"
+  seedFileId: "{{ seed_file_id }}"


### PR DESCRIPTION
Fixes #3576 

## Changes

- Pass seed file id, not presigned url, to crawl job template, and generate presigned URL for seed files in crawl operator as needed
- Track presigned URL expiry and regenerate as needed before the URL expires