### PR TITLE
Modify background job finalizer to only finalize when appropriate

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -680,7 +680,15 @@ class BackgroundJobOps:
             await self.crawl_manager.delete_all_k8s_resources_for_org(str(oid))
 
         job = await self.get_background_job(job_id)
-        if not job or job.finished:
+        if job.finished:
+            logger.debug(
+                "job_already_updated",
+                job_id=job.id,
+                oid=oid,
+                job_type=job_type,
+                success=job.success,
+                finished=job.finished,
+            )
             return
 
         if job.type != job_type:
@@ -746,6 +754,7 @@ class BackgroundJobOps:
 
         res = await self.jobs.find_one(query)
         if not res:
+            logger.error("job_not_found", job_id=job_id, oid=oid)
             raise HTTPException(status_code=404, detail="job_not_found")
 
         return self._get_job_by_type_from_data(res)

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 import structlog
+from fastapi import HTTPException
 
 from btrixcloud.utils import (
     dt_now,
@@ -56,7 +57,7 @@ class BgJobOperator(BaseOperator):
         start_time = status.get("startTime")
         completion_time = status.get("completionTime")
 
-        finalized = True
+        finalized = False
 
         started = None
         finished = None
@@ -83,12 +84,24 @@ class BgJobOperator(BaseOperator):
                 finished=finished,
                 oid=org_id,
             )
+            finalized = True
 
-        # pylint: disable=broad-except
-        except Exception:
-            finalized = False
+        except HTTPException as exc:
+            # If job couldn't be found, most likely case is that the
+            # org and jobs were already deleted and we should finalize
+            # anyway to avoid looping forever
+            if exc.status_code == 404:
+                finalized = True
             logger.exception(
                 "background_job_update_failed",
+                will_retry=not finalized,
+                unstructured_message="Update Background Job Error",
+            )
+        # pylint: disable=broad-except
+        except Exception:
+            logger.exception(
+                "background_job_update_failed",
+                will_retry=True,
                 unstructured_message="Update Background Job Error",
             )
 

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -87,11 +87,14 @@ class BgJobOperator(BaseOperator):
             finalized = True
 
         except HTTPException as exc:
-            # If job couldn't be found, most likely case is that the
-            # org and jobs were already deleted and we should finalize
-            # anyway to avoid looping forever
-            if exc.status_code == 404:
-                finalized = True
+            # If job couldn't be found, it's possible the org has been
+            # deleted, which deletes this job from the database as well.
+            # If the org doesn't exist, finalize to avoid an endless loop.
+            if exc.status_code == 404 and org_id:
+                try:
+                    _ = await self.org_ops.get_org_by_id(org_id)
+                except HTTPException:
+                    finalized = True
             logger.exception(
                 "background_job_update_failed",
                 will_retry=not finalized,

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -88,8 +88,8 @@ class BgJobOperator(BaseOperator):
 
         except HTTPException as exc:
             # If job couldn't be found, it's possible the org has been
-            # deleted, which deletes this job from the database as well.
-            # If the org doesn't exist, finalize to avoid an endless loop.
+            # deleted, which deletes background jobs from the database
+            # as well. If so, finalize anyway to avoid an endless loop.
             if exc.status_code == 404 and org_id:
                 try:
                     _ = await self.org_ops.get_org_by_id(org_id)

--- a/backend/btrixcloud/operator/bgjobs.py
+++ b/backend/btrixcloud/operator/bgjobs.py
@@ -86,6 +86,7 @@ class BgJobOperator(BaseOperator):
 
         # pylint: disable=broad-except
         except Exception:
+            finalized = False
             logger.exception(
                 "background_job_update_failed",
                 unstructured_message="Update Background Job Error",


### PR DESCRIPTION
Fixes #3571

Generally speaking, issues with running the `job_finished` method will now result in the finalizer returning `finalized: False`, which will allow the finalizer to try again on the next sync.

If the exception is due to the job not being found and there is evidence the org was deleted, we still set `finalized: True` in the response to prevent endlessly looping the finalizer hook, as there's nothing to update.