### PR TITLE
task: Add onboarding analytics events

### DIFF
--- a/frontend/src/trackEvents.ts
+++ b/frontend/src/trackEvents.ts
@@ -23,4 +23,10 @@ export enum AnalyticsTrackEvent {
   TrialCreatedWorkflow = "[Trial] Created workflow",
   TrialReplayedCrawledItem = "[Trial] Replayed crawled item",
   TrialVisitedBillingTab = "[Trial] Visited billing tab",
+  /**
+   * User Guide
+   */
+  OpenedCrawlingOnePageGuide = "Opened crawling one page guide",
+  OpenedCrawlingSocialMediaGuide = "Opened crawling social media guide",
+  OpenedCrawlingWebsiteGuide = "Opened crawling website guide",
 }

--- a/frontend/src/trackEvents.ts
+++ b/frontend/src/trackEvents.ts
@@ -16,4 +16,11 @@ export enum AnalyticsTrackEvent {
    * Workflows
    */
   ExpandWorkflowFormSection = "Expand workflow form section",
+  /**
+   * Trial
+   */
+  TrialOpenedUserGuide = "[Trial] Opened user guide",
+  TrialCreatedWorkflow = "[Trial] Created workflow",
+  TrialReplayedCrawledItem = "[Trial] Replayed crawled item",
+  TrialVisitedBillingTab = "[Trial] Visited billing tab",
 }

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -10,6 +10,7 @@ import { AnalyticsTrackEvent } from "../trackEvents";
 export type AnalyticsTrackProps = {
   org_slug?: string | null;
   logged_in?: boolean;
+  trialing?: boolean;
   collection_slug?: string;
   section?: string;
 };


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix/issues/2304

## Changes

Adds additional track events for analytics.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>