### PR TITLE
Ensure BackgroundJobOps.split_bucket() always returns consistent trailing slashes

### DIFF
--- a/backend/btrixcloud/background_jobs.py
+++ b/backend/btrixcloud/background_jobs.py
@@ -95,7 +95,9 @@ class BackgroundJobOps:
     def strip_bucket(self, endpoint_url: str) -> tuple[str, str]:
         """split the endpoint_url into the origin and return rest of endpoint as bucket path"""
         parts = urlsplit(endpoint_url)
-        return parts.scheme + "://" + parts.netloc + "/", parts.path[1:]
+        return os.path.join(f"{parts.scheme}://{parts.netloc}", ""), os.path.join(
+            parts.path[1:], ""
+        )
 
     async def handle_replica_job_succeeded(self, job: CreateReplicaJob) -> None:
         """Update replicas in corresponding file objects, based on type"""

--- a/backend/test/test_unit_background_jobs.py
+++ b/backend/test/test_unit_background_jobs.py
@@ -153,3 +153,53 @@ async def test_postprocess_upload_job_other_create_failure_returns_none(bg_job_o
         uuid.uuid4(), "upload-test-crawl"
     )
     assert job_id is None
+
+
+@pytest.mark.parametrize(
+    "endpoint_url, expected_origin, expected_bucket_path",
+    [
+        # Endpoint URL with no bucket name and no trailing slash
+        # (as might be entered by user directly in chart)
+        (
+            "http://local-minio:9000/test-bucket",
+            "http://local-minio:9000/",
+            "test-bucket/",
+        ),
+        # Endpoint URL with trailing slash (as might be entered
+        # by user directly in chart or constructed by storage ops
+        # from endpoint url and bucket name configured separately)
+        (
+            "http://local-minio:9000/test-bucket/",
+            "http://local-minio:9000/",
+            "test-bucket/",
+        ),
+        # More realistic URLs
+        (
+            "https://s3provider.example.com/btrix-replica-bucket",
+            "https://s3provider.example.com/",
+            "btrix-replica-bucket/",
+        ),
+        (
+            "https://s3provider.example.com/btrix-replica-bucket/",
+            "https://s3provider.example.com/",
+            "btrix-replica-bucket/",
+        ),
+    ],
+)
+def test_strip_bucket_consistent_trailing_slashes(
+    bg_job_ops, endpoint_url, expected_origin, expected_bucket_path
+):
+    """Both values returned should always terminate in one trailing slash
+
+    This helps us consistently build file paths and avoids errors due to missing or doubled
+    path separators.
+    """
+    origin, bucket_path = bg_job_ops.strip_bucket(endpoint_url)
+
+    assert origin == expected_origin
+    assert origin.endswith("/")
+    assert not origin.endswith("//")
+
+    assert bucket_path == expected_bucket_path
+    assert bucket_path.endswith("/")
+    assert not bucket_path.endswith("//")

--- a/backend/test/test_unit_background_jobs.py
+++ b/backend/test/test_unit_background_jobs.py
@@ -184,6 +184,17 @@ async def test_postprocess_upload_job_other_create_failure_returns_none(bg_job_o
             "https://s3provider.example.com/",
             "btrix-replica-bucket/",
         ),
+        # More complicated paths
+        (
+            "https://s3provider.example.com/more/complex/path",
+            "https://s3provider.example.com/",
+            "more/complex/path/",
+        ),
+        (
+            "https://s3provider.example.com/more/complex/path/",
+            "https://s3provider.example.com/",
+            "more/complex/path/",
+        ),
     ],
 )
 def test_strip_bucket_consistent_trailing_slashes(


### PR DESCRIPTION
Fixes #3614 

Would be good to merge this quick fix in before the PRs around file replication and deletion that are anticipated to be in 1.26. Would also be suitable for a patch release if another is released before then.

The first commit adds a new test that demonstrates the problem by failing, then the subsequent commit contain the fix and additional test cases.