### PR TITLE
fix: Fix collection thumbnail search

### DIFF
--- a/frontend/src/features/collections/select-collection-thumbnail.ts
+++ b/frontend/src/features/collections/select-collection-thumbnail.ts
@@ -705,10 +705,13 @@ export class SelectCollectionThumbnail extends BtrixElement {
         }
         break;
       }
-      case "Space":
-        // Prevent closing dropdown
+      case "Enter":
+      case " ": {
+        // Prevent making selection
+        e.preventDefault();
         e.stopPropagation();
         break;
+      }
       default:
         break;
     }


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3618

## Changes

Fixes enter and space key causing the collection thumbnail selector to close.

## Manual testing

1. Log in as crawler
2. Go to collections
3. Select a collection
4. Edit thumbnail
5. Enter text into the URL search bar
6. Press spacebar. Verify thumbnail selector stays open
7. Press enter key. verify thumbnail selector stays open