### PR TITLE
task: Fix extra archived item request

### DIFF
--- a/frontend/src/pages/org/archived-items.ts
+++ b/frontend/src/pages/org/archived-items.ts
@@ -280,13 +280,21 @@ export class CrawlsList extends BtrixElement {
         ? ([range[0] ?? 1, range[1] ?? 5] as const)
         : undefined;
 
-      return {
+      const values = {
         id: params.get("id") ?? undefined,
         name: params.get("name") ?? undefined,
         firstSeed: params.get("firstSeed") ?? undefined,
         state: state.length ? state : undefined,
         reviewStatus,
       };
+
+      if (Object.values(values).some((v) => v !== undefined)) {
+        return values;
+      }
+
+      // Since all values are optional, this can lead to an object with all undefined values,
+      // which should be considered equivalent to when all key-values are deleted from search params
+      return {};
     },
   );
 


### PR DESCRIPTION
Fixes archived items being requested twice due to search param equality check not passing.

No user facing changes since the first request is successfully aborted.