### PR TITLE
feat: Disable setting proxy if profile is selected

### DIFF
--- a/frontend/src/features/crawl-workflows/workflow-editor.ts
+++ b/frontend/src/features/crawl-workflows/workflow-editor.ts
@@ -2288,13 +2288,14 @@ https://archiveweb.page/images/${"logo.svg"}`}
                 .proxyServers=${proxies.servers}
                 .proxyId=${profileProxyId || this.formState.proxyId || ""}
                 .profileProxyId=${this.formState.browserProfile?.proxyId}
+                ?disabled=${!!this.formState.browserProfile}
                 @btrix-change=${(e: SelectCrawlerProxyChangeEvent) =>
                   this.updateFormState({
                     proxyId: e.detail.value,
                   })}
               >
                 ${when(
-                  this.formState.browserProfile?.proxyId,
+                  this.formState.browserProfile,
                   () => html`
                     <span
                       slot="suffix"
@@ -3828,7 +3829,10 @@ https://archiveweb.page/images/${"logo.svg"}`}
       },
       crawlerChannel:
         this.formState.crawlerChannel || CrawlerChannelImage.Default,
-      proxyId: this.formState.browserProfile?.proxyId || this.formState.proxyId,
+      proxyId:
+        (this.formState.browserProfile
+          ? this.formState.browserProfile.proxyId
+          : this.formState.proxyId) || null,
     };
 
     return config;


### PR DESCRIPTION
Resolves https://github.com/webrecorder/browsertrix/issues/3639

## Changes

Disables setting crawler proxy if a browser profile is selected, even if the profile does not have a proxy.

## Manual testing

1. Log in as crawler
2. Go to new workflow
3. Go to "Browser Settings"
4. Select a browser profile without a proxy. Verify "Crawler Proxy Server" is disabled